### PR TITLE
Hive on Spark yarn-cluster mode

### DIFF
--- a/accumulo-handler/src/java/org/apache/hadoop/hive/accumulo/Utils.java
+++ b/accumulo-handler/src/java/org/apache/hadoop/hive/accumulo/Utils.java
@@ -42,6 +42,7 @@ import java.util.zip.ZipOutputStream;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.common.JavaUtils;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.log4j.Logger;
 
@@ -207,7 +208,7 @@ public class Utils {
     Class<?> jarFinder = null;
     try {
       log.debug("Looking for " + hadoopJarFinder + ".");
-      jarFinder = Class.forName(hadoopJarFinder);
+      jarFinder = JavaUtils.loadClass(hadoopJarFinder);
       log.debug(hadoopJarFinder + " found.");
       Method getJar = jarFinder.getMethod("getJar", Class.class);
       ret = (String) getJar.invoke(null, my_class);

--- a/accumulo-handler/src/java/org/apache/hadoop/hive/accumulo/predicate/PrimitiveComparisonFilter.java
+++ b/accumulo-handler/src/java/org/apache/hadoop/hive/accumulo/predicate/PrimitiveComparisonFilter.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.hive.accumulo.columns.ColumnMappingFactory;
 import org.apache.hadoop.hive.accumulo.columns.HiveAccumuloColumnMapping;
 import org.apache.hadoop.hive.accumulo.predicate.compare.CompareOp;
 import org.apache.hadoop.hive.accumulo.predicate.compare.PrimitiveComparison;
+import org.apache.hadoop.hive.common.JavaUtils;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.io.Text;
 import org.apache.log4j.Logger;
@@ -117,8 +118,8 @@ public class PrimitiveComparisonFilter extends WholeRowIterator {
     cqHolder = new Text();
 
     try {
-      Class<?> pClass = Class.forName(options.get(P_COMPARE_CLASS));
-      Class<?> cClazz = Class.forName(options.get(COMPARE_OPT_CLASS));
+      Class<?> pClass = JavaUtils.loadClass(options.get(P_COMPARE_CLASS));
+      Class<?> cClazz = JavaUtils.loadClass(options.get(COMPARE_OPT_CLASS));
       PrimitiveComparison pCompare = pClass.asSubclass(PrimitiveComparison.class).newInstance();
       compOpt = cClazz.asSubclass(CompareOp.class).newInstance();
       byte[] constant = getConstant(options);

--- a/accumulo-handler/src/java/org/apache/hadoop/hive/accumulo/serde/AccumuloSerDeParameters.java
+++ b/accumulo-handler/src/java/org/apache/hadoop/hive/accumulo/serde/AccumuloSerDeParameters.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.hive.accumulo.AccumuloConnectionParameters;
 import org.apache.hadoop.hive.accumulo.columns.ColumnMapper;
 import org.apache.hadoop.hive.accumulo.columns.ColumnMapping;
 import org.apache.hadoop.hive.accumulo.columns.HiveAccumuloRowIdColumnMapping;
+import org.apache.hadoop.hive.common.JavaUtils;
 import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.hive.serde2.SerDeException;
 import org.apache.hadoop.hive.serde2.lazy.LazySerDeParameters;
@@ -116,7 +117,7 @@ public class AccumuloSerDeParameters extends AccumuloConnectionParameters {
     String factoryClassName = tbl.getProperty(COMPOSITE_ROWID_FACTORY);
     if (factoryClassName != null) {
       log.info("Loading CompositeRowIdFactory class " + factoryClassName);
-      Class<?> factoryClazz = Class.forName(factoryClassName);
+      Class<?> factoryClazz = JavaUtils.loadClass(factoryClassName);
       return (AccumuloRowIdFactory) ReflectionUtils.newInstance(factoryClazz, job);
     }
 
@@ -124,7 +125,7 @@ public class AccumuloSerDeParameters extends AccumuloConnectionParameters {
     String keyClassName = tbl.getProperty(COMPOSITE_ROWID_CLASS);
     if (keyClassName != null) {
       log.info("Loading CompositeRowId class " + keyClassName);
-      Class<?> keyClass = Class.forName(keyClassName);
+      Class<?> keyClass = JavaUtils.loadClass(keyClassName);
       Class<? extends AccumuloCompositeRowId> compositeRowIdClass = keyClass
           .asSubclass(AccumuloCompositeRowId.class);
       return new CompositeAccumuloRowIdFactory(compositeRowIdClass);

--- a/common/src/java/org/apache/hadoop/hive/common/JavaUtils.java
+++ b/common/src/java/org/apache/hadoop/hive/common/JavaUtils.java
@@ -70,6 +70,14 @@ public final class JavaUtils {
     return classLoader;
   }
 
+  public static Class loadClass(String className) throws ClassNotFoundException {
+    return loadClass(className, true);
+  }
+
+  public static Class loadClass(String className, boolean init) throws ClassNotFoundException {
+    return Class.forName(className, init, getClassLoader());
+  }
+
   public static boolean closeClassLoadersTo(ClassLoader current, ClassLoader stop) {
     if (!isValidHierarchy(current, stop)) {
       return false;

--- a/data/conf/spark/yarn-client/hive-site.xml
+++ b/data/conf/spark/yarn-client/hive-site.xml
@@ -197,7 +197,7 @@
 
 <property>
   <name>spark.master</name>
-  <value>yarn-client</value>
+  <value>yarn-cluster</value>
 </property>
 
 <property>
@@ -253,6 +253,17 @@
 <property>
   <name>hive.enable.spark.execution.engine</name>
   <value>true</value>
+</property>
+
+  <property>
+  <name>hive.in.test</name>
+  <value>true</value>
+  <description>Internal marker for test. Used for masking env-dependent values</description>
+</property>
+
+<property>
+  <name>hive.spark.client.connect.timeout</name>
+  <value>30000ms</value>
 </property>
 
 </configuration>

--- a/hbase-handler/src/java/org/apache/hadoop/hive/hbase/HBaseSerDeHelper.java
+++ b/hbase-handler/src/java/org/apache/hadoop/hive/hbase/HBaseSerDeHelper.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.common.JavaUtils;
 import org.apache.hadoop.hive.hbase.ColumnMappings.ColumnMapping;
 import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.hive.serde2.SerDeException;
@@ -466,7 +467,7 @@ public class HBaseSerDeHelper {
       throws SerDeException {
     Class<?> serClass;
     try {
-      serClass = Class.forName(serClassName);
+      serClass = JavaUtils.loadClass(serClassName);
     } catch (ClassNotFoundException e) {
       throw new SerDeException("Error obtaining descriptor for " + serClassName, e);
     }
@@ -562,7 +563,7 @@ public class HBaseSerDeHelper {
 
     Class<?> keyClass;
     try {
-      keyClass = Class.forName(compKeyClassName);
+      keyClass = JavaUtils.loadClass(compKeyClassName);
       keyFactory = new CompositeHBaseKeyFactory(keyClass);
     } catch (Exception e) {
       throw new SerDeException(e);

--- a/hbase-handler/src/java/org/apache/hadoop/hive/hbase/HBaseSerDeParameters.java
+++ b/hbase-handler/src/java/org/apache/hadoop/hive/hbase/HBaseSerDeParameters.java
@@ -25,6 +25,7 @@ import java.util.Properties;
 import org.apache.avro.Schema;
 import org.apache.avro.reflect.ReflectData;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.common.JavaUtils;
 import org.apache.hadoop.hive.hbase.ColumnMappings.ColumnMapping;
 import org.apache.hadoop.hive.hbase.struct.AvroHBaseValueFactory;
 import org.apache.hadoop.hive.hbase.struct.DefaultHBaseValueFactory;
@@ -200,7 +201,7 @@ public class HBaseSerDeParameters {
     if (configuration != null) {
       return configuration.getClassByName(className);
     }
-    return Class.forName(className);
+    return JavaUtils.loadClass(className);
   }
 
   private List<HBaseValueFactory> initValueFactories(Configuration conf, Properties tbl)

--- a/hcatalog/webhcat/svr/src/main/java/org/apache/hive/hcatalog/templeton/tool/JobState.java
+++ b/hcatalog/webhcat/svr/src/main/java/org/apache/hive/hcatalog/templeton/tool/JobState.java
@@ -70,7 +70,7 @@ public class JobState {
     TempletonStorage storage = null;
     try {
       storage = (TempletonStorage)
-        Class.forName(conf.get(TempletonStorage.STORAGE_CLASS))
+          Class.forName(conf.get(TempletonStorage.STORAGE_CLASS))
           .newInstance();
     } catch (Exception e) {
       LOG.warn("No storage method found: " + e.getMessage());

--- a/itests/src/test/resources/testconfiguration.properties
+++ b/itests/src/test/resources/testconfiguration.properties
@@ -1026,6 +1026,7 @@ miniSparkOnYarn.query.files=auto_sortmerge_join_16.q,\
   empty_dir_in_table.q,\
   external_table_with_space_in_location_path.q,\
   file_with_header_footer.q,\
+  gen_udf_example_add10.q,\
   import_exported_table.q,\
   index_bitmap3.q,\
   index_bitmap_auto.q,\

--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
     <ST4.version>4.0.4</ST4.version>
     <tez.version>0.5.2</tez.version>
     <super-csv.version>2.2.0</super-csv.version>
-    <spark.version>${cdh.spark.version}</spark.version>
+    <spark.version>1.4.0</spark.version>
     <scala.binary.version>2.10</scala.binary.version>
     <scala.version>2.10.4</scala.version>
     <tempus-fugit.version>1.1</tempus-fugit.version>

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -458,12 +458,10 @@
       <version>${spark.version}</version>
       <optional>true</optional>
     </dependency>
-    <!-- Following have only one version, which is cdh.hadoop.version -->
     <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-common</artifactId>
-      <version>${hadoop-23.version}</version>
-      <optional>true</optional>
+      <groupId>com.sun.jersey</groupId>
+      <artifactId>jersey-servlet</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/Utilities.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/Utilities.java
@@ -377,6 +377,7 @@ public final class Utilities {
           ClassLoader loader = Thread.currentThread().getContextClassLoader();
           ClassLoader newLoader = addToClassPath(loader, addedJars.split(";"));
           Thread.currentThread().setContextClassLoader(newLoader);
+          runtimeSerializationKryo.get().setClassLoader(newLoader);
         }
       }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/mr/ExecDriver.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/mr/ExecDriver.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.CompressionUtils;
+import org.apache.hadoop.hive.common.JavaUtils;
 import org.apache.hadoop.hive.common.LogUtils;
 import org.apache.hadoop.hive.common.LogUtils.LogInitializationException;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -239,8 +240,8 @@ public class ExecDriver extends Task<MapredWork> implements Serializable, Hadoop
     job.setMapOutputValueClass(BytesWritable.class);
 
     try {
-      job.setPartitionerClass((Class<? extends Partitioner>) (Class.forName(HiveConf.getVar(job,
-          HiveConf.ConfVars.HIVEPARTITIONER))));
+      String partitioner = HiveConf.getVar(job, ConfVars.HIVEPARTITIONER);
+      job.setPartitionerClass((Class<? extends Partitioner>) JavaUtils.loadClass(partitioner));
     } catch (ClassNotFoundException e) {
       throw new RuntimeException(e.getMessage(), e);
     }
@@ -286,7 +287,7 @@ public class ExecDriver extends Task<MapredWork> implements Serializable, Hadoop
     LOG.info("Using " + inpFormat);
 
     try {
-      job.setInputFormat((Class<? extends InputFormat>) (Class.forName(inpFormat)));
+      job.setInputFormat((Class<? extends InputFormat>) JavaUtils.loadClass(inpFormat));
     } catch (ClassNotFoundException e) {
       throw new RuntimeException(e.getMessage(), e);
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/persistence/MapJoinTableContainerSerDe.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/persistence/MapJoinTableContainerSerDe.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.common.JavaUtils;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.serde2.SerDe;
 import org.apache.hadoop.hive.serde2.SerDeException;
@@ -194,7 +195,7 @@ public class MapJoinTableContainerSerDe {
     try {
       @SuppressWarnings("unchecked")
       Class<? extends MapJoinPersistableTableContainer> clazz =
-          (Class<? extends MapJoinPersistableTableContainer>)Class.forName(name);
+          (Class<? extends MapJoinPersistableTableContainer>) JavaUtils.loadClass(name);
       Constructor<? extends MapJoinPersistableTableContainer> constructor =
           clazz.getDeclaredConstructor(Map.class);
       return constructor.newInstance(metaData);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/spark/HiveSparkClientFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/spark/HiveSparkClientFactory.java
@@ -132,6 +132,11 @@ public class HiveSparkClientFactory {
         LOG.info(String.format(
           "load yarn property from hive configuration in %s mode (%s -> %s).",
           sparkMaster, propertyName, value));
+      } else if (propertyName.equals(HiveConf.ConfVars.HADOOPFS.varname)) {
+        String value = hiveConf.get(propertyName);
+        if (value != null && !value.isEmpty()) {
+          sparkConf.put("spark.hadoop." + propertyName, value);
+        }
       }
       if (RpcConfiguration.HIVE_SPARK_RSC_CONFIGS.contains(propertyName)) {
         String value = RpcConfiguration.getValue(hiveConf, propertyName);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/spark/KryoSerializer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/spark/KryoSerializer.java
@@ -80,4 +80,8 @@ public class KryoSerializer {
     return conf;
   }
 
+  public static void setClassLoader(ClassLoader classLoader) {
+    Utilities.sparkSerializationKryo.get().setClassLoader(classLoader);
+  }
+
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/spark/RemoteHiveSparkClient.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/spark/RemoteHiveSparkClient.java
@@ -297,9 +297,10 @@ public class RemoteHiveSparkClient implements HiveSparkClient {
       // may need to load classes from this jar in other threads.
       Map<String, Long> addedJars = jc.getAddedJars();
       if (addedJars != null && !addedJars.isEmpty()) {
-        SparkClientUtilities.addToClassPath(addedJars, localJobConf, jc.getLocalTmpDir());
+        List<String> localAddedJars = SparkClientUtilities.addToClassPath(addedJars,
+            localJobConf, jc.getLocalTmpDir());
         KryoSerializer.setClassLoader(Thread.currentThread().getContextClassLoader());
-        localJobConf.set(Utilities.HIVE_ADDED_JARS, StringUtils.join(addedJars.keySet(), ";"));
+        localJobConf.set(Utilities.HIVE_ADDED_JARS, StringUtils.join(localAddedJars, ";"));
       }
 
       Path localScratchDir = KryoSerializer.deserialize(scratchDirBytes, Path.class);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/spark/RemoteHiveSparkClient.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/spark/RemoteHiveSparkClient.java
@@ -276,6 +276,7 @@ public class RemoteHiveSparkClient implements HiveSparkClient {
       Set<String> addedJars = jc.getAddedJars();
       if (addedJars != null && !addedJars.isEmpty()) {
         SparkClientUtilities.addToClassPath(addedJars, localJobConf, jc.getLocalTmpDir());
+        KryoSerializer.setClassLoader(Thread.currentThread().getContextClassLoader());
         localJobConf.set(Utilities.HIVE_ADDED_JARS, StringUtils.join(addedJars, ";"));
       }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/spark/RemoteHiveSparkClient.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/spark/RemoteHiveSparkClient.java
@@ -273,11 +273,11 @@ public class RemoteHiveSparkClient implements HiveSparkClient {
 
       // Add jar to current thread class loader dynamically, and add jar paths to JobConf as Spark
       // may need to load classes from this jar in other threads.
-      Set<String> addedJars = jc.getAddedJars();
+      Map<String, Long> addedJars = jc.getAddedJars();
       if (addedJars != null && !addedJars.isEmpty()) {
         SparkClientUtilities.addToClassPath(addedJars, localJobConf, jc.getLocalTmpDir());
         KryoSerializer.setClassLoader(Thread.currentThread().getContextClassLoader());
-        localJobConf.set(Utilities.HIVE_ADDED_JARS, StringUtils.join(addedJars, ";"));
+        localJobConf.set(Utilities.HIVE_ADDED_JARS, StringUtils.join(addedJars.keySet(), ";"));
       }
 
       Path localScratchDir = KryoSerializer.deserialize(scratchDirBytes, Path.class);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/spark/SparkPlanGenerator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/spark/SparkPlanGenerator.java
@@ -28,6 +28,7 @@ import com.google.common.base.Preconditions;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.common.JavaUtils;
 import org.apache.hadoop.hive.ql.io.merge.MergeFileMapper;
 import org.apache.hadoop.hive.ql.io.merge.MergeFileOutputFormat;
 import org.apache.hadoop.hive.ql.io.merge.MergeFileWork;
@@ -168,7 +169,7 @@ public class SparkPlanGenerator {
 
     Class inputFormatClass;
     try {
-      inputFormatClass = Class.forName(inpFormat);
+      inputFormatClass = JavaUtils.loadClass(inpFormat);
     } catch (ClassNotFoundException e) {
       String message = "Failed to load specified input format class:"
           + inpFormat;
@@ -246,7 +247,7 @@ public class SparkPlanGenerator {
     HiveConf.setVar(cloned, HiveConf.ConfVars.PLAN, "");
     try {
       cloned.setPartitionerClass((Class<? extends Partitioner>)
-          (Class.forName(HiveConf.getVar(cloned, HiveConf.ConfVars.HIVEPARTITIONER))));
+          JavaUtils.loadClass(HiveConf.getVar(cloned, HiveConf.ConfVars.HIVEPARTITIONER)));
     } catch (ClassNotFoundException e) {
       String msg = "Could not find partitioner class: " + e.getMessage()
         + " which is specified by: " + HiveConf.ConfVars.HIVEPARTITIONER.varname;

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/spark/SparkUtilities.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/spark/SparkUtilities.java
@@ -78,7 +78,8 @@ public class SparkUtilities {
    */
   public static URI uploadToHDFS(URI source, HiveConf conf) throws IOException {
     Path localFile = new Path(source.getPath());
-    Path remoteFile = new Path(SessionState.getHDFSSessionPath(conf), getFileName(source));
+    Path remoteFile = new Path(SessionState.get().getSparkSession().getHDFSSessionDir(),
+        getFileName(source));
     FileSystem fileSystem = FileSystem.get(conf);
     // Overwrite if the remote file already exists. Whether the file can be added
     // on executor is up to spark, i.e. spark.files.overwrite

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/spark/SparkUtilities.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/spark/SparkUtilities.java
@@ -21,7 +21,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.UUID;
+import java.util.Collection;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -78,11 +78,11 @@ public class SparkUtilities {
    */
   public static URI uploadToHDFS(URI source, HiveConf conf) throws IOException {
     Path localFile = new Path(source.getPath());
-    // give the uploaded file a UUID
-    Path remoteFile = new Path(SessionState.getHDFSSessionPath(conf),
-        UUID.randomUUID() + "-" + getFileName(source));
+    Path remoteFile = new Path(SessionState.getHDFSSessionPath(conf), getFileName(source));
     FileSystem fileSystem = FileSystem.get(conf);
-    fileSystem.copyFromLocalFile(localFile, remoteFile);
+    // Overwrite if the remote file already exists. Whether the file can be added
+    // on executor is up to spark, i.e. spark.files.overwrite
+    fileSystem.copyFromLocalFile(false, true, localFile, remoteFile);
     Path fullPath = fileSystem.getFileStatus(remoteFile).getPath();
     return fullPath.toUri();
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/spark/session/SparkSession.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/spark/session/SparkSession.java
@@ -17,12 +17,15 @@
  */
 package org.apache.hadoop.hive.ql.exec.spark.session;
 
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.ObjectPair;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.DriverContext;
 import org.apache.hadoop.hive.ql.exec.spark.status.SparkJobRef;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.plan.SparkWork;
+
+import java.io.IOException;
 
 public interface SparkSession {
   /**
@@ -67,4 +70,9 @@ public interface SparkSession {
    * Close session and release resources.
    */
   void close();
+
+  /**
+   * Get an HDFS dir specific to the SparkSession
+   * */
+  Path getHDFSSessionDir() throws IOException;
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/spark/session/SparkSessionImpl.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/spark/session/SparkSessionImpl.java
@@ -22,6 +22,10 @@ import java.util.UUID;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.hadoop.hive.common.ObjectPair;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.DriverContext;
@@ -37,11 +41,14 @@ import com.google.common.base.Preconditions;
 
 public class SparkSessionImpl implements SparkSession {
   private static final Log LOG = LogFactory.getLog(SparkSession.class);
+  private static final String SPARK_DIR = "_spark_session_dir";
 
   private HiveConf conf;
   private boolean isOpen;
   private final String sessionId;
   private HiveSparkClient hiveSparkClient;
+  private Path scratchDir;
+  private final Object dirLock = new Object();
 
   public SparkSessionImpl() {
     sessionId = makeSessionId();
@@ -118,11 +125,43 @@ public class SparkSessionImpl implements SparkSession {
     if (hiveSparkClient != null) {
       try {
         hiveSparkClient.close();
+        cleanScratchDir();
       } catch (IOException e) {
         LOG.error("Failed to close spark session (" + sessionId + ").", e);
       }
     }
     hiveSparkClient = null;
+  }
+
+  private Path createScratchDir() throws IOException {
+    Path parent = new Path(SessionState.get().getHdfsScratchDirURIString(), SPARK_DIR);
+    Path sparkDir = new Path(parent, sessionId);
+    FileSystem fs = sparkDir.getFileSystem(conf);
+    FsPermission fsPermission = new FsPermission(HiveConf.getVar(
+        conf, HiveConf.ConfVars.SCRATCHDIRPERMISSION));
+    fs.mkdirs(sparkDir, fsPermission);
+    fs.deleteOnExit(sparkDir);
+    return sparkDir;
+  }
+
+  private void cleanScratchDir() throws IOException {
+    if (scratchDir != null) {
+      FileSystem fs = scratchDir.getFileSystem(conf);
+      fs.delete(scratchDir, true);
+      scratchDir = null;
+    }
+  }
+
+  @Override
+  public Path getHDFSSessionDir() throws IOException {
+    if (scratchDir == null) {
+      synchronized (dirLock) {
+        if (scratchDir == null) {
+          scratchDir = createScratchDir();
+        }
+      }
+    }
+    return scratchDir;
   }
 
   public static String makeSessionId() {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/HivePreWarmProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/HivePreWarmProcessor.java
@@ -22,6 +22,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.hive.common.JavaUtils;
 import org.apache.hadoop.io.ReadaheadPool;
 import org.apache.hadoop.hive.shims.ShimLoader;
 import org.apache.tez.common.TezUtils;
@@ -99,7 +100,7 @@ public class HivePreWarmProcessor extends AbstractLogicalIOProcessor {
              * in hive-exec.jar. These are the relatively safe ones - operators & io classes.
              */
             if(klass.indexOf("vector") != -1 || klass.indexOf("Operator") != -1) {
-              Class.forName(klass);
+              JavaUtils.loadClass(klass);
             }
           }
         }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/HiveSplitGenerator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/HiveSplitGenerator.java
@@ -28,6 +28,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.common.JavaUtils;
 import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.io.HiveFileFormatUtils;
 import org.apache.hadoop.hive.ql.plan.MapWork;
@@ -114,7 +115,7 @@ public class HiveSplitGenerator extends InputInitializer {
     if (groupingEnabled) {
       // Need to instantiate the realInputFormat
       InputFormat<?, ?> inputFormat =
-          (InputFormat<?, ?>) ReflectionUtils.newInstance(Class.forName(realInputFormatName),
+          (InputFormat<?, ?>) ReflectionUtils.newInstance(JavaUtils.loadClass(realInputFormatName),
               jobConf);
 
       int totalResource = rootInputContext.getTotalAvailableResource().getMemory();

--- a/ql/src/java/org/apache/hadoop/hive/ql/index/compact/CompactIndexHandler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/index/compact/CompactIndexHandler.java
@@ -28,7 +28,7 @@ import java.util.Set;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hive.common.StatsSetupConst;
+import org.apache.hadoop.hive.common.JavaUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
@@ -220,7 +220,7 @@ public class CompactIndexHandler extends TableBasedIndexHandler {
           // We can only perform a binary search with HiveInputFormat and CombineHiveInputFormat
           // and BucketizedHiveInputFormat
           try {
-            if (!HiveInputFormat.class.isAssignableFrom(Class.forName(inputFormat))) {
+            if (!HiveInputFormat.class.isAssignableFrom(JavaUtils.loadClass(inputFormat))) {
               work = null;
               break;
             }

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/CombineHiveRecordReader.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/CombineHiveRecordReader.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.hive.ql.io;
 import java.io.IOException;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.common.JavaUtils;
 import org.apache.hadoop.hive.ql.exec.mr.ExecMapper;
 import org.apache.hadoop.hive.ql.io.CombineHiveInputFormat.CombineHiveInputSplit;
 import org.apache.hadoop.io.Writable;
@@ -50,7 +51,7 @@ public class CombineHiveRecordReader<K extends WritableComparable, V extends Wri
     String inputFormatClassName = hsplit.inputFormatClassName();
     Class inputFormatClass = null;
     try {
-      inputFormatClass = Class.forName(inputFormatClassName);
+      inputFormatClass = JavaUtils.loadClass(inputFormatClassName);
     } catch (ClassNotFoundException e) {
       throw new IOException("CombineHiveRecordReader: class not found "
           + inputFormatClassName);

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/HiveFileFormatUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/HiveFileFormatUtils.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.common.JavaUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.exec.FileSinkOperator.RecordWriter;
 import org.apache.hadoop.hive.ql.exec.Operator;
@@ -232,8 +233,8 @@ public final class HiveFileFormatUtils {
         jc_output = new JobConf(jc);
         String codecStr = conf.getCompressCodec();
         if (codecStr != null && !codecStr.trim().equals("")) {
-          Class<? extends CompressionCodec> codec = (Class<? extends CompressionCodec>) Class
-              .forName(codecStr);
+          Class<? extends CompressionCodec> codec = 
+              (Class<? extends CompressionCodec>) JavaUtils.loadClass(codecStr);
           FileOutputFormat.setOutputCompressorClass(jc_output, codec);
         }
         String type = conf.getCompressType();

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/WriterImpl.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/WriterImpl.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.common.JavaUtils;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.io.IOConstants;
@@ -286,7 +287,7 @@ class WriterImpl implements Writer, MemoryManager.Callback {
         try {
           Class<? extends CompressionCodec> lzo =
               (Class<? extends CompressionCodec>)
-                  Class.forName("org.apache.hadoop.hive.ql.io.orc.LzoCodec");
+                  JavaUtils.loadClass("org.apache.hadoop.hive.ql.io.orc.LzoCodec");
           return lzo.newInstance();
         } catch (ClassNotFoundException e) {
           throw new IllegalArgumentException("LZO is not available.", e);

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/rcfile/stats/PartialScanTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/rcfile/stats/PartialScanTask.java
@@ -31,6 +31,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.common.JavaUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.Context;
 import org.apache.hadoop.hive.ql.DriverContext;
@@ -144,8 +145,7 @@ public class PartialScanTask extends Task<PartialScanWork> implements
     LOG.info("Using " + inpFormat);
 
     try {
-      job.setInputFormat((Class<? extends InputFormat>) (Class
-          .forName(inpFormat)));
+      job.setInputFormat((Class<? extends InputFormat>) JavaUtils.loadClass(inpFormat));
     } catch (ClassNotFoundException e) {
       throw new RuntimeException(e.getMessage(), e);
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/rcfile/truncate/ColumnTruncateTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/rcfile/truncate/ColumnTruncateTask.java
@@ -24,6 +24,7 @@ import java.io.Serializable;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.common.JavaUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.Context;
 import org.apache.hadoop.hive.ql.DriverContext;
@@ -120,8 +121,7 @@ public class ColumnTruncateTask extends Task<ColumnTruncateWork> implements Seri
     LOG.info("Using " + inpFormat);
 
     try {
-      job.setInputFormat((Class<? extends InputFormat>) (Class
-          .forName(inpFormat)));
+      job.setInputFormat((Class<? extends InputFormat>) JavaUtils.loadClass(inpFormat));
     } catch (ClassNotFoundException e) {
       throw new RuntimeException(e.getMessage(), e);
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/AbstractSMBJoinProc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/AbstractSMBJoinProc.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Stack;
 
+import org.apache.hadoop.hive.common.JavaUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.Order;
 import org.apache.hadoop.hive.ql.ErrorMsg;
@@ -440,10 +441,10 @@ abstract public class AbstractSMBJoinProc extends AbstractBucketJoinProc impleme
 
     Class<? extends BigTableSelectorForAutoSMJ> bigTableMatcherClass = null;
     try {
+      String selector = HiveConf.getVar(pGraphContext.getConf(),
+          HiveConf.ConfVars.HIVE_AUTO_SORTMERGE_JOIN_BIGTABLE_SELECTOR);
       bigTableMatcherClass =
-        (Class<? extends BigTableSelectorForAutoSMJ>)
-          (Class.forName(HiveConf.getVar(pGraphContext.getConf(),
-            HiveConf.ConfVars.HIVE_AUTO_SORTMERGE_JOIN_BIGTABLE_SELECTOR)));
+        (Class<? extends BigTableSelectorForAutoSMJ>) JavaUtils.loadClass(selector);
     } catch (ClassNotFoundException e) {
       throw new SemanticException(e.getMessage());
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ConvertJoinMapJoin.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ConvertJoinMapJoin.java
@@ -28,6 +28,7 @@ import java.util.Stack;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.hive.common.JavaUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.exec.AppMasterEventOperator;
 import org.apache.hadoop.hive.ql.exec.CommonMergeJoinOperator;
@@ -181,10 +182,10 @@ public class ConvertJoinMapJoin implements NodeProcessor {
     }
     Class<? extends BigTableSelectorForAutoSMJ> bigTableMatcherClass = null;
     try {
+      String selector = HiveConf.getVar(context.parseContext.getConf(),
+          HiveConf.ConfVars.HIVE_AUTO_SORTMERGE_JOIN_BIGTABLE_SELECTOR);
       bigTableMatcherClass =
-          (Class<? extends BigTableSelectorForAutoSMJ>) (Class.forName(HiveConf.getVar(
-              context.parseContext.getConf(),
-              HiveConf.ConfVars.HIVE_AUTO_SORTMERGE_JOIN_BIGTABLE_SELECTOR)));
+          (Class<? extends BigTableSelectorForAutoSMJ>) JavaUtils.loadClass(selector);
     } catch (ClassNotFoundException e) {
       throw new SemanticException(e.getMessage());
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/DDLSemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/DDLSemanticAnalyzer.java
@@ -45,6 +45,7 @@ import org.antlr.runtime.tree.Tree;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.common.JavaUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hadoop.hive.metastore.MetaStoreUtils;
@@ -1036,7 +1037,7 @@ public class DDLSemanticAnalyzer extends BaseSemanticAnalyzer {
       typeName = indexType.getHandlerClsName();
     } else {
       try {
-        Class.forName(typeName);
+        JavaUtils.loadClass(typeName);
       } catch (Exception e) {
         throw new SemanticException("class name provided for index handler not found.", e);
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/PTFDeserializer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/PTFDeserializer.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.common.JavaUtils;
 import org.apache.hadoop.hive.ql.exec.ExprNodeEvaluator;
 import org.apache.hadoop.hive.ql.exec.PTFPartition;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
@@ -288,7 +288,7 @@ public class PTFDeserializer {
     try {
       @SuppressWarnings("unchecked")
       Class<? extends TableFunctionResolver> rCls = (Class<? extends TableFunctionResolver>)
-          Class.forName(className);
+          JavaUtils.loadClass(className);
       return ReflectionUtils.newInstance(rCls, null);
     } catch (Exception e) {
       throw new HiveException(e);

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/PlanUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/PlanUtils.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.common.JavaUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hadoop.hive.metastore.MetaStoreUtils;
@@ -145,7 +146,7 @@ public final class PlanUtils {
             serdeConstants.SERIALIZATION_LIB, localDirectoryDesc.getSerName());
       }
       if (localDirectoryDesc.getOutputFormat() != null){
-          ret.setOutputFileFormatClass(Class.forName(localDirectoryDesc.getOutputFormat()));
+        ret.setOutputFileFormatClass(JavaUtils.loadClass(localDirectoryDesc.getOutputFormat()));
       }
       if (localDirectoryDesc.getNullFormat() != null) {
         properties.setProperty(serdeConstants.SERIALIZATION_NULL_FORMAT,
@@ -308,7 +309,7 @@ public final class PlanUtils {
 
     try {
       if (crtTblDesc.getSerName() != null) {
-        Class c = Class.forName(crtTblDesc.getSerName());
+        Class c = JavaUtils.loadClass(crtTblDesc.getSerName());
         serdeClass = c;
       }
 
@@ -360,8 +361,8 @@ public final class PlanUtils {
 
       // replace the default input & output file format with those found in
       // crtTblDesc
-      Class c1 = Class.forName(crtTblDesc.getInputFormat());
-      Class c2 = Class.forName(crtTblDesc.getOutputFormat());
+      Class c1 = JavaUtils.loadClass(crtTblDesc.getInputFormat());
+      Class c2 = JavaUtils.loadClass(crtTblDesc.getOutputFormat());
       Class<? extends InputFormat> in_class = c1;
       Class<? extends HiveOutputFormat> out_class = c2;
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/stats/jdbc/JDBCStatsAggregator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/stats/jdbc/JDBCStatsAggregator.java
@@ -32,6 +32,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.common.JavaUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.exec.Task;
 import org.apache.hadoop.hive.ql.exec.Utilities;
@@ -69,7 +70,7 @@ public class JDBCStatsAggregator implements StatsAggregator {
     this.sourceTask = sourceTask;
 
     try {
-      Class.forName(driver).newInstance();
+      JavaUtils.loadClass(driver).newInstance();
     } catch (Exception e) {
       LOG.error("Error during instantiating JDBC driver " + driver + ". ", e);
       return false;

--- a/ql/src/java/org/apache/hadoop/hive/ql/stats/jdbc/JDBCStatsPublisher.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/stats/jdbc/JDBCStatsPublisher.java
@@ -35,6 +35,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.common.JavaUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.stats.StatsPublisher;
@@ -69,7 +70,7 @@ public class JDBCStatsPublisher implements StatsPublisher {
     String driver = HiveConf.getVar(hiveconf, HiveConf.ConfVars.HIVESTATSJDBCDRIVER);
 
     try {
-      Class.forName(driver).newInstance();
+      JavaUtils.loadClass(driver).newInstance();
     } catch (Exception e) {
       LOG.error("Error during instantiating JDBC driver " + driver + ". ", e);
       return false;
@@ -272,7 +273,7 @@ public class JDBCStatsPublisher implements StatsPublisher {
       this.hiveconf = hconf;
       connectionString = HiveConf.getVar(hconf, HiveConf.ConfVars.HIVESTATSDBCONNECTIONSTRING);
       String driver = HiveConf.getVar(hconf, HiveConf.ConfVars.HIVESTATSJDBCDRIVER);
-      Class.forName(driver).newInstance();
+      JavaUtils.loadClass(driver).newInstance();
       synchronized(DriverManager.class) {
         DriverManager.setLoginTimeout(timeout);
         conn = DriverManager.getConnection(connectionString);

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/CompactorMR.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/CompactorMR.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.common.JavaUtils;
 import org.apache.hadoop.hive.common.ValidTxnList;
 import org.apache.hadoop.hive.common.ValidReadTxnList;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -647,7 +648,7 @@ public class CompactorMR {
   private static <T> T instantiate(Class<T> classType, String classname) throws IOException {
     T t = null;
     try {
-      Class c = Class.forName(classname);
+      Class c = JavaUtils.loadClass(classname);
       Object o = c.newInstance();
       if (classType.isAssignableFrom(o.getClass())) {
         t = (T)o;

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFReflect.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFReflect.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hive.ql.udf.generic;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 
+import org.apache.hadoop.hive.common.JavaUtils;
 import org.apache.hadoop.hive.ql.exec.Description;
 import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
 import org.apache.hadoop.hive.ql.exec.UDFArgumentLengthException;
@@ -102,7 +103,7 @@ public class GenericUDFReflect extends AbstractGenericUDFReflect {
       className = ObjectInspectorUtils.copyToStandardObject(newClassName, inputClassNameOI);
       String classNameString = classNameOI.getPrimitiveJavaObject(className);
       try {
-        c = Class.forName(classNameString);
+        c = JavaUtils.loadClass(classNameString);
       } catch (ClassNotFoundException ex) {
         throw new HiveException("UDFReflect evaluate ", ex);
       }

--- a/spark-client/pom.xml
+++ b/spark-client/pom.xml
@@ -69,6 +69,11 @@
       <artifactId>mockito-all</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.sun.jersey</groupId>
+      <artifactId>jersey-servlet</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/spark-client/src/main/java/org/apache/hive/spark/client/JobContext.java
+++ b/spark-client/src/main/java/org/apache/hive/spark/client/JobContext.java
@@ -55,9 +55,9 @@ public interface JobContext {
   Map<String, List<JavaFutureAction<?>>> getMonitoredJobs();
 
   /**
-   * Return all added jar path which added through AddJarJob.
+   * Return all added jar path and timestamp which added through AddJarJob.
    */
-  Set<String> getAddedJars();
+  Map<String, Long> getAddedJars();
 
   /**
    * Returns a local tmp dir specific to the context

--- a/spark-client/src/main/java/org/apache/hive/spark/client/JobContextImpl.java
+++ b/spark-client/src/main/java/org/apache/hive/spark/client/JobContextImpl.java
@@ -18,12 +18,10 @@
 package org.apache.hive.spark.client;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.apache.hive.spark.counter.SparkCounters;
 
@@ -35,14 +33,14 @@ class JobContextImpl implements JobContext {
   private final JavaSparkContext sc;
   private final ThreadLocal<MonitorCallback> monitorCb;
   private final Map<String, List<JavaFutureAction<?>>> monitoredJobs;
-  private final Set<String> addedJars;
+  private final Map<String, Long> addedJars;
   private final File localTmpDir;
 
   public JobContextImpl(JavaSparkContext sc, File localTmpDir) {
     this.sc = sc;
     this.monitorCb = new ThreadLocal<MonitorCallback>();
     monitoredJobs = new ConcurrentHashMap<String, List<JavaFutureAction<?>>>();
-    addedJars = Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>());
+    addedJars = new ConcurrentHashMap<>();
     this.localTmpDir = localTmpDir;
   }
 
@@ -65,7 +63,7 @@ class JobContextImpl implements JobContext {
   }
 
   @Override
-  public Set<String> getAddedJars() {
+  public Map<String, Long> getAddedJars() {
     return addedJars;
   }
 

--- a/spark-client/src/main/java/org/apache/hive/spark/client/SparkClient.java
+++ b/spark-client/src/main/java/org/apache/hive/spark/client/SparkClient.java
@@ -94,4 +94,9 @@ public interface SparkClient extends Serializable {
    * Get default parallelism. For standalone mode, this can be used to get total number of cores.
    */
   Future<Integer> getDefaultParallelism();
+
+  /**
+   * Check if remote context is still active.
+   */
+  boolean isActive();
 }

--- a/spark-client/src/main/java/org/apache/hive/spark/client/SparkClientImpl.java
+++ b/spark-client/src/main/java/org/apache/hive/spark/client/SparkClientImpl.java
@@ -178,6 +178,11 @@ class SparkClientImpl implements SparkClient {
     return run(new GetDefaultParallelismJob());
   }
 
+  @Override
+  public boolean isActive() {
+    return isAlive && driverRpc.isActive();
+  }
+
   void cancel(String jobId) {
     protocol.cancel(jobId);
   }

--- a/spark-client/src/main/java/org/apache/hive/spark/client/SparkClientImpl.java
+++ b/spark-client/src/main/java/org/apache/hive/spark/client/SparkClientImpl.java
@@ -612,7 +612,7 @@ class SparkClientImpl implements SparkClient {
       jc.sc().addJar(path);
       // Following remote job may refer to classes in this jar, and the remote job would be executed
       // in a different thread, so we add this jar path to JobContext for further usage.
-      jc.getAddedJars().add(path);
+      jc.getAddedJars().put(path, System.currentTimeMillis());
       return null;
     }
 

--- a/spark-client/src/main/java/org/apache/hive/spark/client/SparkClientUtilities.java
+++ b/spark-client/src/main/java/org/apache/hive/spark/client/SparkClientUtilities.java
@@ -43,21 +43,24 @@ public class SparkClientUtilities {
    */
   public static void addToClassPath(Set<String> newPaths, Configuration conf, File localTmpDir)
       throws Exception {
-    ClassLoader cloader = Thread.currentThread().getContextClassLoader();
-    URLClassLoader loader = (URLClassLoader) cloader;
+    URLClassLoader loader = (URLClassLoader) Thread.currentThread().getContextClassLoader();
     List<URL> curPath = Lists.newArrayList(loader.getURLs());
 
+    boolean newPathAdded = false;
     for (String newPath : newPaths) {
       URL newUrl = urlFromPathString(newPath, conf, localTmpDir);
       if (newUrl != null && !curPath.contains(newUrl)) {
         curPath.add(newUrl);
         LOG.info("Added jar[" + newUrl + "] to classpath.");
+        newPathAdded = true;
       }
     }
 
-    URLClassLoader newLoader =
-        new URLClassLoader(curPath.toArray(new URL[curPath.size()]), loader);
-    Thread.currentThread().setContextClassLoader(newLoader);
+    if (newPathAdded) {
+      URLClassLoader newLoader =
+          new URLClassLoader(curPath.toArray(new URL[curPath.size()]), loader);
+      Thread.currentThread().setContextClassLoader(newLoader);
+    }
   }
 
   /**

--- a/spark-client/src/main/java/org/apache/hive/spark/client/SparkClientUtilities.java
+++ b/spark-client/src/main/java/org/apache/hive/spark/client/SparkClientUtilities.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Lists;
 import java.io.File;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -42,15 +43,18 @@ public class SparkClientUtilities {
    * Add new elements to the classpath.
    *
    * @param newPaths Map of classpath elements and corresponding timestamp
+   * @return locally accessible files corresponding to the newPaths
    */
-  public static void addToClassPath(Map<String, Long> newPaths, Configuration conf, File localTmpDir)
-      throws Exception {
+  public static List<String> addToClassPath(Map<String, Long> newPaths, Configuration conf,
+      File localTmpDir) throws Exception {
     URLClassLoader loader = (URLClassLoader) Thread.currentThread().getContextClassLoader();
     List<URL> curPath = Lists.newArrayList(loader.getURLs());
+    List<String> localNewPaths = new ArrayList<>();
 
     boolean newPathAdded = false;
     for (Map.Entry<String, Long> entry : newPaths.entrySet()) {
       URL newUrl = urlFromPathString(entry.getKey(), entry.getValue(), conf, localTmpDir);
+      localNewPaths.add(newUrl.toString());
       if (newUrl != null && !curPath.contains(newUrl)) {
         curPath.add(newUrl);
         LOG.info("Added jar[" + newUrl + "] to classpath.");
@@ -63,6 +67,7 @@ public class SparkClientUtilities {
           new URLClassLoader(curPath.toArray(new URL[curPath.size()]), loader);
       Thread.currentThread().setContextClassLoader(newLoader);
     }
+    return localNewPaths;
   }
 
   /**

--- a/spark-client/src/main/java/org/apache/hive/spark/client/rpc/Rpc.java
+++ b/spark-client/src/main/java/org/apache/hive/spark/client/rpc/Rpc.java
@@ -259,6 +259,10 @@ public class Rpc implements Closeable {
     return call(msg, Void.class);
   }
 
+  public boolean isActive() {
+    return channel.isActive();
+  }
+
   /**
    * Send an RPC call to the remote endpoint and returns a future that can be used to monitor the
    * operation.

--- a/spark-client/src/test/java/org/apache/hive/spark/client/TestSparkClient.java
+++ b/spark-client/src/test/java/org/apache/hive/spark/client/TestSparkClient.java
@@ -168,7 +168,7 @@ public class TestSparkClient {
         future.get(TIMEOUT, TimeUnit.SECONDS);
         MetricsCollection metrics = future.getMetrics();
         assertEquals(1, metrics.getJobIds().size());
-        assertTrue(metrics.getAllMetrics().executorRunTime > 0L);
+        assertTrue(metrics.getAllMetrics().executorRunTime >= 0L);
         verify(listener).onSparkJobStarted(same(future),
           eq(metrics.getJobIds().iterator().next()));
 
@@ -179,7 +179,7 @@ public class TestSparkClient {
         MetricsCollection metrics2 = future2.getMetrics();
         assertEquals(1, metrics2.getJobIds().size());
         assertFalse(Objects.equal(metrics.getJobIds(), metrics2.getJobIds()));
-        assertTrue(metrics2.getAllMetrics().executorRunTime > 0L);
+        assertTrue(metrics2.getAllMetrics().executorRunTime >= 0L);
         verify(listener2).onSparkJobStarted(same(future2),
           eq(metrics2.getJobIds().iterator().next()));
       }


### PR DESCRIPTION
We need two patches HIVE-9486 and HIVE-12045 for yarn-cluster mode. These basically change the classloader of hive to use the ones that pick up from the jars where they are placed in yarn-cluster mode.

There are three other patches being brought in as they are pre-requisite for these two.