### PR TITLE
Backport HIVE-13968

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/CombineHiveInputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/CombineHiveInputFormat.java
@@ -116,7 +116,7 @@ public class CombineHiveInputFormat<K extends WritableComparable, V extends Writ
             LOG.debug("The path [" + paths[i + start] +
                 "] is being parked for HiveInputFormat.getSplits");
           }
-          nonCombinablePathIndices.add(i);
+          nonCombinablePathIndices.add(i + start);
         }
       }
       return nonCombinablePathIndices;


### PR DESCRIPTION
CheckNonCombinablePathCallable should give absolute index of paths