### PR TITLE
Mockito should be in test scope

### DIFF
--- a/shims/scheduler/pom.xml
+++ b/shims/scheduler/pom.xml
@@ -86,6 +86,7 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
       <version>${mockito-all.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
      <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
Mockito as a compile time dependency will be included into transitive dependency for other projects, and cause some conflict with other libraries (such as hamcrest)