### PR TITLE
Named struct evolution

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -1042,6 +1042,9 @@ public class HiveConf extends Configuration {
         "This controls how many partitions can be scanned for each partitioned table.\n" +
         "The default value \"-1\" means no limit. (DEPRECATED: Please use " + ConfVars.METASTORE_LIMIT_PARTITION_REQUEST + " in the metastore instead.)"),
 
+    HIVE_STRUCT_EVOLUTION_ACCESS_BY_NAME("hive.named.struct.evolution.name.access", false,
+        "If named structs have diverged in the partition and table partitions, use name to resolve the struct."),
+
     HIVEHASHTABLEKEYCOUNTADJUSTMENT("hive.hashtable.key.count.adjustment", 1.0f,
         "Adjustment to mapjoin hashtable size derived from table and column statistics; the estimate" +
         " of the number of keys is divided by this value. If the value is 0, statistics are not used" +

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -1042,8 +1042,8 @@ public class HiveConf extends Configuration {
         "This controls how many partitions can be scanned for each partitioned table.\n" +
         "The default value \"-1\" means no limit. (DEPRECATED: Please use " + ConfVars.METASTORE_LIMIT_PARTITION_REQUEST + " in the metastore instead.)"),
 
-    HIVE_STRUCT_EVOLUTION_ACCESS_BY_NAME("hive.named.struct.evolution.name.access", false,
-        "If named structs have diverged in the partition and table partitions, use name to resolve the struct."),
+    HIVE_STRUCT_EVOLUTION_ACCESS_BY_NAME("hive.struct.evolution.name.access", false,
+        "If structs have diverged in the partition and table partitions, use name to resolve the struct."),
 
     HIVEHASHTABLEKEYCOUNTADJUSTMENT("hive.hashtable.key.count.adjustment", 1.0f,
         "Adjustment to mapjoin hashtable size derived from table and column statistics; the estimate" +

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/FetchOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/FetchOperator.java
@@ -302,14 +302,9 @@ public class FetchOperator implements Serializable {
       } else {
         currSerDe = needConversion(currDesc) ? currDesc.getDeserializer(job) : tableSerDe;
         ObjectInspector inputOI = currSerDe.getObjectInspector();
-        ObjectConverter = ObjectInspectorConverters.getConverter(inputOI, convertedOI);
+        ObjectConverter = ObjectInspectorConverters.getConverter(inputOI, convertedOI, job);
       }
 
-      if (ObjectConverter instanceof ObjectInspectorConverters.StructConverter) {
-        if (job.getBoolean(HiveConf.ConfVars.HIVE_STRUCT_EVOLUTION_ACCESS_BY_NAME.varname, false)) {
-          ((ObjectInspectorConverters.StructConverter) ObjectConverter).setResolveByName(true);
-        }
-      }
       if (isPartitioned) {
         row[1] = createPartValue(currDesc, partKeyOI);
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/FetchOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/FetchOperator.java
@@ -304,6 +304,12 @@ public class FetchOperator implements Serializable {
         ObjectInspector inputOI = currSerDe.getObjectInspector();
         ObjectConverter = ObjectInspectorConverters.getConverter(inputOI, convertedOI);
       }
+
+      if (ObjectConverter instanceof ObjectInspectorConverters.StructConverter) {
+        if (job.getBoolean(HiveConf.ConfVars.HIVE_STRUCT_EVOLUTION_ACCESS_BY_NAME.varname, false)) {
+          ((ObjectInspectorConverters.StructConverter) ObjectConverter).setResolveByName(true);
+        }
+      }
       if (isPartitioned) {
         row[1] = createPartValue(currDesc, partKeyOI);
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/read/DataWritableReadSupport.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/read/DataWritableReadSupport.java
@@ -118,7 +118,7 @@ public class DataWritableReadSupport extends ReadSupport<ArrayWritable> {
 
       Type fieldType = getFieldTypeIgnoreCase(schema, colName);
       if (fieldType == null) {
-        schemaTypes.add(Types.optional(PrimitiveTypeName.BINARY).named(colName));
+        //schemaTypes.add(Types.optional(PrimitiveTypeName.BINARY).named(colName));
       } else {
         schemaTypes.add(getProjectedType(colType, fieldType));
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/read/DataWritableReadSupport.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/read/DataWritableReadSupport.java
@@ -117,9 +117,7 @@ public class DataWritableReadSupport extends ReadSupport<ArrayWritable> {
       String colName = columnIterator.next();
 
       Type fieldType = getFieldTypeIgnoreCase(schema, colName);
-      if (fieldType == null) {
-        //schemaTypes.add(Types.optional(PrimitiveTypeName.BINARY).named(colName));
-      } else {
+      if (fieldType != null) {
         schemaTypes.add(getProjectedType(colType, fieldType));
       }
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/serde/ParquetHiveSerDe.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/serde/ParquetHiveSerDe.java
@@ -110,10 +110,6 @@ public class ParquetHiveSerDe extends AbstractSerDe {
     final String columnNameProperty = tbl.getProperty(serdeConstants.LIST_COLUMNS);
     final String columnTypeProperty = tbl.getProperty(serdeConstants.LIST_COLUMN_TYPES);
 
-    //Override on the job-conf so that the fetch operator's row reader gets the latest column types
-    conf.set(serdeConstants.LIST_COLUMNS, columnNameProperty);
-    conf.set(serdeConstants.LIST_COLUMN_TYPES, columnTypeProperty);
-
     if (columnNameProperty.length() == 0 && columnTypeProperty.length() == 0) {
         final String locationProperty = tbl.getProperty("location", null);
         Path parquetFile = locationProperty != null ? getParquetFile(conf,

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/serde/ParquetHiveSerDe.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/serde/ParquetHiveSerDe.java
@@ -110,6 +110,10 @@ public class ParquetHiveSerDe extends AbstractSerDe {
     final String columnNameProperty = tbl.getProperty(serdeConstants.LIST_COLUMNS);
     final String columnTypeProperty = tbl.getProperty(serdeConstants.LIST_COLUMN_TYPES);
 
+    //Override on the job-conf so that the fetch operator's row reader gets the latest column types
+    conf.set(serdeConstants.LIST_COLUMNS, columnNameProperty);
+    conf.set(serdeConstants.LIST_COLUMN_TYPES, columnTypeProperty);
+
     if (columnNameProperty.length() == 0 && columnTypeProperty.length() == 0) {
         final String locationProperty = tbl.getProperty("location", null);
         Path parquetFile = locationProperty != null ? getParquetFile(conf,

--- a/ql/src/test/results/clientpositive/parquet_struct_schema_evolution.q.out
+++ b/ql/src/test/results/clientpositive/parquet_struct_schema_evolution.q.out
@@ -1,0 +1,96 @@
+PREHOOK: query: -- this test creates a Parquet table with an array of structs
+create table test_schema (
+  struct_field struct<col1:string,col2:int>
+)
+partitioned by (
+  pname string
+)
+stored as parquet
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@test_schema
+POSTHOOK: query: -- this test creates a Parquet table with an array of structs
+create table test_schema (
+  struct_field struct<col1:string,col2:int>
+)
+partitioned by (
+  pname string
+)
+stored as parquet
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@test_schema
+PREHOOK: query: -- insert first partition with initial schema
+insert into table test_schema partition (pname="old") select struct('a', 1)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test_schema@pname=old
+POSTHOOK: query: -- insert first partition with initial schema
+insert into table test_schema partition (pname="old") select struct('a', 1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test_schema@pname=old
+POSTHOOK: Lineage: test_schema PARTITION(pname=old).struct_field EXPRESSION []
+PREHOOK: query: -- table is modified to have more structs
+alter table test_schema change column struct_field struct_field struct<col0:int,col1:string,col2:int>
+PREHOOK: type: ALTERTABLE_RENAMECOL
+PREHOOK: Input: default@test_schema
+PREHOOK: Output: default@test_schema
+POSTHOOK: query: -- table is modified to have more structs
+alter table test_schema change column struct_field struct_field struct<col0:int,col1:string,col2:int>
+POSTHOOK: type: ALTERTABLE_RENAMECOL
+POSTHOOK: Input: default@test_schema
+POSTHOOK: Output: default@test_schema
+PREHOOK: query: select * from test_schema
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_schema
+PREHOOK: Input: default@test_schema@pname=old
+#### A masked pattern was here ####
+POSTHOOK: query: select * from test_schema
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_schema
+POSTHOOK: Input: default@test_schema@pname=old
+#### A masked pattern was here ####
+{"col0":null,"col1":"a","col2":1}	old
+PREHOOK: query: -- table is modified to have fewer structs
+alter table test_schema change column struct_field struct_field struct<col2:int>
+PREHOOK: type: ALTERTABLE_RENAMECOL
+PREHOOK: Input: default@test_schema
+PREHOOK: Output: default@test_schema
+POSTHOOK: query: -- table is modified to have fewer structs
+alter table test_schema change column struct_field struct_field struct<col2:int>
+POSTHOOK: type: ALTERTABLE_RENAMECOL
+POSTHOOK: Input: default@test_schema
+POSTHOOK: Output: default@test_schema
+PREHOOK: query: select * from test_schema
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_schema
+PREHOOK: Input: default@test_schema@pname=old
+#### A masked pattern was here ####
+POSTHOOK: query: select * from test_schema
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_schema
+POSTHOOK: Input: default@test_schema@pname=old
+#### A masked pattern was here ####
+{"col2":1}	old
+PREHOOK: query: -- table is modified to be equivalent to the partition structs
+alter table test_schema change column struct_field struct_field struct<col1:string,col2:int>
+PREHOOK: type: ALTERTABLE_RENAMECOL
+PREHOOK: Input: default@test_schema
+PREHOOK: Output: default@test_schema
+POSTHOOK: query: -- table is modified to be equivalent to the partition structs
+alter table test_schema change column struct_field struct_field struct<col1:string,col2:int>
+POSTHOOK: type: ALTERTABLE_RENAMECOL
+POSTHOOK: Input: default@test_schema
+POSTHOOK: Output: default@test_schema
+PREHOOK: query: select * from test_schema
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_schema
+PREHOOK: Input: default@test_schema@pname=old
+#### A masked pattern was here ####
+POSTHOOK: query: select * from test_schema
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_schema
+POSTHOOK: Input: default@test_schema@pname=old
+#### A masked pattern was here ####
+{"col1":"a","col2":1}	old

--- a/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorConverters.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorConverters.java
@@ -395,7 +395,9 @@ public final class ObjectInspectorConverters {
         }
         for (StructField in : inputFields) {
           StructField out = outputFieldsByName.get(in.getFieldName().toLowerCase());
-          fieldConverters.add(getConverter(in.getFieldObjectInspector(), out.getFieldObjectInspector(), conf));
+          if (out != null) {
+            fieldConverters.add(getConverter(in.getFieldObjectInspector(), out.getFieldObjectInspector(), conf));
+          }
         }
 
         //For lookup by index

--- a/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorConverters.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorConverters.java
@@ -371,9 +371,8 @@ public final class ObjectInspectorConverters {
         inputFields = this.inputOI.getAllStructFieldRefs();
         outputFields = outputOI.getAllStructFieldRefs();
 
-        Map<String, StructField> outputFieldsByName = new HashMap<>();
-
         //For lookup by name
+        Map<String, StructField> outputFieldsByName = new HashMap<>();
         for (StructField out : outputFields) {
           outputFieldsByName.put(out.getFieldName().toLowerCase(), out);
         }
@@ -448,6 +447,12 @@ public final class ObjectInspectorConverters {
 
     public void setResolveByName(boolean resolveByName) {
       this.resolveByName = resolveByName;
+      for (Pair<StructField, Converter> value : outputAndConverterByName.values()) {
+        Converter c = value.getSecond();
+        if (c instanceof StructConverter) {
+          ((StructConverter) c).setResolveByName(resolveByName);
+        }
+      }
     }
   }
 

--- a/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorConverters.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorConverters.java
@@ -366,7 +366,7 @@ public final class ObjectInspectorConverters {
     List<? extends StructField> inputFields;
     List<? extends StructField> outputFields;
 
-    boolean resolveByName = false;  //if input and output schemas differ, resolved struct cols by name, else resolve by index
+    boolean resolveByName = false;  //if input and output schemas differ, resolved struct cols by name or by index
     ArrayList<Converter> fieldConverters = new ArrayList<>();  //used by resolve struct cols by name
     Map<String, Pair<StructField, Converter>> outputAndConverterByName = new HashMap<>();  //used by resolve struct cols by index
 
@@ -375,7 +375,9 @@ public final class ObjectInspectorConverters {
     public StructConverter(ObjectInspector inputOI,
         SettableStructObjectInspector outputOI, Configuration conf) {
       if (inputOI instanceof StructObjectInspector) {
-        resolveByName = conf.getBoolean(HiveConf.ConfVars.HIVE_STRUCT_EVOLUTION_ACCESS_BY_NAME.varname, false);
+        if (conf != null) {
+          resolveByName = conf.getBoolean(HiveConf.ConfVars.HIVE_STRUCT_EVOLUTION_ACCESS_BY_NAME.varname, false);
+        }
 
         this.inputOI = (StructObjectInspector)inputOI;
         this.outputOI = outputOI;

--- a/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorConverters.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorConverters.java
@@ -389,14 +389,9 @@ public final class ObjectInspectorConverters {
         for (StructField in : inputFields) {
           StructField out = outputFieldsByName.get(in.getFieldName().toLowerCase());
           if (out != null) {
+            Converter converter = getConverter(in.getFieldObjectInspector(), out.getFieldObjectInspector(), conf);
             outputAndConverterByName.put(in.getFieldName().toLowerCase(),
-              new Pair<>(out, getConverter(in.getFieldObjectInspector(), out.getFieldObjectInspector(), conf)));
-          }
-        }
-        for (StructField in : inputFields) {
-          StructField out = outputFieldsByName.get(in.getFieldName().toLowerCase());
-          if (out != null) {
-            fieldConverters.add(getConverter(in.getFieldObjectInspector(), out.getFieldObjectInspector(), conf));
+              new Pair<>(out, converter));
           }
         }
 


### PR DESCRIPTION
This change fixes schema evolution in the type conversion step.  The conversion here being between an old partition (one with less structs) to the new table schema (one with more structs). 

The conversion used to be by index, this changes it to be by name.

The parquet Serde needed only minimal changes, it removes one Optional Binary to the read schema added in https://issues.apache.org/jira/browse/HIVE-6456 by Justin in 2014 (!) for case if there is a new struct, I will do more investigation to see whether its needed or not.