### PR TITLE
Bump Kryo version to 4.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
     <json.version>20090211</json.version>
     <jsp.api.version>2.1</jsp.api.version>
     <junit.version>4.11</junit.version>
-    <kryo.version>2.22</kryo.version>
+    <kryo.version>4.0.2</kryo.version>
     <libfb303.version>${cdh.thrift.version}</libfb303.version>
     <libthrift.version>${cdh.thrift.version}</libthrift.version>
     <log4j.version>1.2.16</log4j.version>
@@ -255,7 +255,7 @@
     <dependencies>
       <!-- dependencies are always listed in sorted order by groupId, artifectId -->
       <dependency>
-        <groupId>com.esotericsoftware.kryo</groupId>
+        <groupId>com.esotericsoftware</groupId>
         <artifactId>kryo</artifactId>
         <version>${kryo.version}</version>
       </dependency>

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -85,7 +85,7 @@
     </dependency>
     <!-- inter-project -->
     <dependency>
-      <groupId>com.esotericsoftware.kryo</groupId>
+      <groupId>com.esotericsoftware</groupId>
       <artifactId>kryo</artifactId>
       <version>${kryo.version}</version>
     </dependency>

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/Utilities.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/Utilities.java
@@ -207,7 +207,7 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import com.esotericsoftware.kryo.serializers.FieldSerializer;
-import com.esotericsoftware.shaded.org.objenesis.strategy.StdInstantiatorStrategy;
+import org.objenesis.strategy.StdInstantiatorStrategy;
 
 /**
  * Utilities.

--- a/spark-client/pom.xml
+++ b/spark-client/pom.xml
@@ -38,7 +38,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.esotericsoftware.kryo</groupId>
+      <groupId>com.esotericsoftware</groupId>
       <artifactId>kryo</artifactId>
     </dependency>
     <dependency>

--- a/spark-client/src/main/java/org/apache/hive/spark/client/rpc/KryoMessageCodec.java
+++ b/spark-client/src/main/java/org/apache/hive/spark/client/rpc/KryoMessageCodec.java
@@ -27,7 +27,7 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.ByteBufferInputStream;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
-import com.esotericsoftware.shaded.org.objenesis.strategy.StdInstantiatorStrategy;
+import org.objenesis.strategy.StdInstantiatorStrategy;
 import com.google.common.base.Preconditions;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;


### PR DESCRIPTION
Avoid using Kryo with shading that generates complexity
when using Hive-exec within other applications.