### PR TITLE
Force joda-time version in root pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -380,6 +380,13 @@
         <artifactId>jline</artifactId>
         <version>${jline.version}</version>
       </dependency>
+      <!-- Force this version to be 2.8.1 -->
+      <!-- If not specified, maven revolves it to 1.6 -->
+      <dependency>
+        <groupId>joda-time</groupId>
+        <artifactId>joda-time</artifactId>
+        <version>${joda.version}</version>
+      </dependency>
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>


### PR DESCRIPTION
For some reason, Maven resolves this version
to 1.6 when creating the archive.