### PR TITLE
Named-based schema matching between table and partitions

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -1439,6 +1439,10 @@ public class HiveConf extends Configuration {
         "However, if it is on, and the predicated number of entries in hashtable for a given join \n" +
         "input is larger than this number, the join will not be converted to a mapjoin. \n" +
         "The value \"-1\" means no limit."),
+
+    HIVE_STRUCT_SCHEMA_CONVERSION_BY_NAME("hive.struct.schema.name.access", false,
+            "If structs have diverged in the partition and table partitions, use name to resolve the struct."),
+
     HIVEHASHTABLEKEYCOUNTADJUSTMENT("hive.hashtable.key.count.adjustment", 1.0f,
         "Adjustment to mapjoin hashtable size derived from table and column statistics; the estimate" +
         " of the number of keys is divided by this value. If the value is 0, statistics are not used" +

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/FetchOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/FetchOperator.java
@@ -311,7 +311,7 @@ public class FetchOperator implements Serializable {
       } else {
         currSerDe = needConversion(currDesc) ? currDesc.getDeserializer(job) : tableSerDe;
         ObjectInspector inputOI = currSerDe.getObjectInspector();
-        ObjectConverter = ObjectInspectorConverters.getConverter(inputOI, convertedOI);
+        ObjectConverter = ObjectInspectorConverters.getConverter(inputOI, convertedOI, job);
       }
       if (isPartitioned) {
         row[1] = createPartValue(currDesc, partKeyOI);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/MapOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/MapOperator.java
@@ -193,7 +193,7 @@ public class MapOperator extends AbstractMapOperator {
     }
 
     opCtx.partTblObjectInspectorConverter =
-        ObjectInspectorConverters.getConverter(partRawRowObjectInspector, tableRowOI);
+        ObjectInspectorConverters.getConverter(partRawRowObjectInspector, tableRowOI, hconf);
 
     // Next check if this table has partitions and if so
     // get the list of partition names as well as allocate

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/serde/ParquetHiveSerDe.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/serde/ParquetHiveSerDe.java
@@ -29,7 +29,12 @@ import org.apache.hadoop.hive.ql.io.parquet.convert.ParquetToHiveSchemaConverter
 // END blind imports
 
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 
 import com.google.common.base.Preconditions;
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/serde/ParquetHiveSerDe.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/serde/ParquetHiveSerDe.java
@@ -22,22 +22,19 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hadoop.hive.ql.io.parquet.convert.ParquetSchemaReader;
 import org.apache.hadoop.hive.ql.io.parquet.convert.ParquetToHiveSchemaConverter;
 //
 // END blind imports
 
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
+import java.util.*;
 
 import com.google.common.base.Preconditions;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.ql.metadata.VirtualColumn;
 import org.apache.hadoop.hive.ql.optimizer.FieldNode;
 import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.hive.serde2.AbstractSerDe;
@@ -49,6 +46,7 @@ import org.apache.hadoop.hive.serde2.SerDeUtils;
 import org.apache.hadoop.hive.serde2.io.ParquetHiveRecord;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorConverters;
 import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
@@ -57,6 +55,7 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
 import org.apache.hadoop.io.ArrayWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.util.StringUtils;
 import org.apache.parquet.hadoop.ParquetOutputFormat;
 
 /**
@@ -87,6 +86,7 @@ public class ParquetHiveSerDe extends AbstractSerDe {
 
   private SerDeStats stats;
   private ObjectInspector objInspector;
+  private ObjectInspectorConverters.Converter tableToPartitionConverter;
 
   private enum LAST_OPERATION {
     SERIALIZE,
@@ -185,13 +185,48 @@ public class ParquetHiveSerDe extends AbstractSerDe {
         List<String> prunedColumnPaths = processRawPrunedPaths(rawPrunedColumnPaths);
         prunedTypeInfo = pruneFromPaths(completeTypeInfo, prunedColumnPaths);
       }
+
+      boolean resolveByName = conf.getBoolean(ConfVars.HIVE_STRUCT_SCHEMA_CONVERSION_BY_NAME.varname, false);
+      if (resolveByName) {
+        ObjectInspector tableOI = getTableObjectInspector(conf);
+        if (tableOI != null) {
+          this.tableToPartitionConverter = ObjectInspectorConverters.getConverter(tableOI, objInspector, conf);
+        }
+      }
     }
+
     this.objInspector = new ArrayWritableObjectInspector(completeTypeInfo, prunedTypeInfo);
+    if (this.tableToPartitionConverter == null) {
+      this.tableToPartitionConverter = new ObjectInspectorConverters.IdentityConverter();
+    }
 
     // Stats part
     serializedSize = 0;
     deserializedSize = 0;
     status = LAST_OPERATION.UNKNOWN;
+  }
+
+  private ObjectInspector getTableObjectInspector(final Configuration conf) {
+    final String columnNameProperty = conf.get(serdeConstants.LIST_COLUMNS);
+    final String columnTypeProperty = conf.get(serdeConstants.LIST_COLUMN_TYPES);
+
+    if (columnNameProperty == null || columnTypeProperty == null) {
+      return null;
+    }
+
+    List<String> columnNames = Collections.emptyList();
+    List<TypeInfo> columnTypes = Collections.emptyList();
+    if (!columnNameProperty.isEmpty()) {
+      columnNames = (List<String>) VirtualColumn.
+              removeVirtualColumns(StringUtils.getStringCollection(columnNameProperty));
+
+      if (!columnNames.isEmpty()) {
+        columnTypes = TypeInfoUtils.getTypeInfosFromTypeString(columnTypeProperty);
+      }
+    }
+
+    TypeInfo tableTypeInfo = TypeInfoFactory.getStructTypeInfo(columnNames, columnTypes);
+    return new ArrayWritableObjectInspector((StructTypeInfo) tableTypeInfo);
   }
 
   @Override
@@ -200,7 +235,7 @@ public class ParquetHiveSerDe extends AbstractSerDe {
     deserializedSize = 0;
     if (blob instanceof ArrayWritable) {
       deserializedSize = ((ArrayWritable) blob).get().length;
-      return blob;
+      return tableToPartitionConverter.convert(blob);
     } else {
       return null;
     }

--- a/ql/src/test/queries/clientpositive/parquet_schema_evolution_by_name.q
+++ b/ql/src/test/queries/clientpositive/parquet_schema_evolution_by_name.q
@@ -1,0 +1,65 @@
+-- When the partition schema and the table schema do not match in a parquet table, if the appropriate
+￼-- config is set then the matching can be done by name
+￼
+￼SET hive.struct.schema.name.access=true;
+￼
+￼DROP TABLE parquet_schema_evolution_by_name;
+￼DROP TABLE parquet_schema_evolution_by_name_struct;
+￼
+￼-- Table to test schema evolution at base level
+￼CREATE TABLE parquet_schema_evolution_by_name (col0 int, col1 double)
+￼PARTITIONED BY (pname string)
+￼STORED AS PARQUET;
+￼
+￼-- Insert a first row with the original schema
+￼INSERT INTO TABLE parquet_schema_evolution_by_name PARTITION (pname='1')
+￼  SELECT 1, 1.0;
+￼
+￼-- Reorder the columns within the schema
+￼ALTER TABLE parquet_schema_evolution_by_name replace columns (col1 double, col0 int);
+￼INSERT INTO TABLE parquet_schema_evolution_by_name PARTITION (pname='2')
+￼  SELECT 2.0, 2;
+￼
+￼SELECT * FROM parquet_schema_evolution_by_name;
+￼
+￼-- Add a new field in the middle of the schema
+￼ALTER TABLE parquet_schema_evolution_by_name replace columns (col2 string, col1 double, col0 int);
+￼INSERT INTO TABLE parquet_schema_evolution_by_name PARTITION (pname='3')
+￼  SELECT 'three', 3.0, 3;
+￼
+￼SELECT * FROM parquet_schema_evolution_by_name;
+￼
+￼
+￼-- Table to test schema evolution at struct level
+￼CREATE TABLE parquet_schema_evolution_by_name_struct (f struct<col0:int,col1:double>)
+￼PARTITIONED BY (pname string)
+￼STORED AS PARQUET;
+￼
+￼-- Insert a first row with the original schema
+￼INSERT INTO TABLE parquet_schema_evolution_by_name_struct PARTITION (pname='1')
+￼  SELECT named_struct('col0', 1, 'col1', 1.0);
+￼
+￼-- Reorder the columns within the schema
+￼ALTER TABLE parquet_schema_evolution_by_name_struct change column f f struct<col1:double,col0:int>;
+￼INSERT INTO TABLE parquet_schema_evolution_by_name_struct PARTITION (pname='2')
+￼  SELECT named_struct('col1', 2.0, 'col0', 2);
+￼
+￼SELECT * FROM parquet_schema_evolution_by_name_struct;
+￼
+￼-- Add a new field in the middle of the schema
+￼ALTER TABLE parquet_schema_evolution_by_name_struct change column f f struct<col2:string,col1:double,col0:int>;
+￼INSERT INTO TABLE parquet_schema_evolution_by_name_struct PARTITION (pname='3')
+￼  SELECT named_struct('col2', 'three', 'col1', 3.0, 'col0', 3);
+￼
+￼SELECT * FROM parquet_schema_evolution_by_name_struct;
+￼
+￼-- Remove a field from the middle of the schema
+￼ALTER TABLE parquet_schema_evolution_by_name_struct change column f f struct<col2:string,col0:int>;
+￼INSERT INTO TABLE parquet_schema_evolution_by_name_struct PARTITION (pname='4')
+￼  SELECT named_struct('col2', 'four', 'col0', 4);
+￼
+￼SELECT * FROM parquet_schema_evolution_by_name_struct;
+￼
+￼-- Clean up
+￼DROP TABLE parquet_schema_evolution_by_name;
+￼DROP TABLE parquet_schema_evolution_by_name_struct;

--- a/ql/src/test/results/clientpositive/parquet_schema_evolution_by_name.q.out
+++ b/ql/src/test/results/clientpositive/parquet_schema_evolution_by_name.q.out
@@ -1,0 +1,271 @@
+PREHOOK: query: DROP TABLE parquet_schema_evolution_by_name
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: DROP TABLE parquet_schema_evolution_by_name
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: DROP TABLE parquet_schema_evolution_by_name_struct
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: DROP TABLE parquet_schema_evolution_by_name_struct
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: -- Table to test schema evolution at base level
+CREATE TABLE parquet_schema_evolution_by_name (col0 int, col1 double)
+PARTITIONED BY (pname string)
+STORED AS PARQUET
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@parquet_schema_evolution_by_name
+POSTHOOK: query: -- Table to test schema evolution at base level
+CREATE TABLE parquet_schema_evolution_by_name (col0 int, col1 double)
+PARTITIONED BY (pname string)
+STORED AS PARQUET
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@parquet_schema_evolution_by_name
+PREHOOK: query: -- Insert a first row with the original schema
+INSERT INTO TABLE parquet_schema_evolution_by_name PARTITION (pname='1')
+  SELECT 1, 1.0
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@parquet_schema_evolution_by_name@pname=1
+POSTHOOK: query: -- Insert a first row with the original schema
+INSERT INTO TABLE parquet_schema_evolution_by_name PARTITION (pname='1')
+  SELECT 1, 1.0
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@parquet_schema_evolution_by_name@pname=1
+POSTHOOK: Lineage: parquet_schema_evolution_by_name PARTITION(pname=1).col0 SIMPLE []
+POSTHOOK: Lineage: parquet_schema_evolution_by_name PARTITION(pname=1).col1 SIMPLE []
+PREHOOK: query: -- Reorder the columns within the schema
+ALTER TABLE parquet_schema_evolution_by_name replace columns (col1 double, col0 int)
+PREHOOK: type: ALTERTABLE_REPLACECOLS
+PREHOOK: Input: default@parquet_schema_evolution_by_name
+PREHOOK: Output: default@parquet_schema_evolution_by_name
+POSTHOOK: query: -- Reorder the columns within the schema
+ALTER TABLE parquet_schema_evolution_by_name replace columns (col1 double, col0 int)
+POSTHOOK: type: ALTERTABLE_REPLACECOLS
+POSTHOOK: Input: default@parquet_schema_evolution_by_name
+POSTHOOK: Output: default@parquet_schema_evolution_by_name
+PREHOOK: query: INSERT INTO TABLE parquet_schema_evolution_by_name PARTITION (pname='2')
+  SELECT 2.0, 2
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@parquet_schema_evolution_by_name@pname=2
+POSTHOOK: query: INSERT INTO TABLE parquet_schema_evolution_by_name PARTITION (pname='2')
+  SELECT 2.0, 2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@parquet_schema_evolution_by_name@pname=2
+POSTHOOK: Lineage: parquet_schema_evolution_by_name PARTITION(pname=2).col0 SIMPLE []
+POSTHOOK: Lineage: parquet_schema_evolution_by_name PARTITION(pname=2).col1 SIMPLE []
+PREHOOK: query: SELECT * FROM parquet_schema_evolution_by_name
+PREHOOK: type: QUERY
+PREHOOK: Input: default@parquet_schema_evolution_by_name
+PREHOOK: Input: default@parquet_schema_evolution_by_name@pname=1
+PREHOOK: Input: default@parquet_schema_evolution_by_name@pname=2
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT * FROM parquet_schema_evolution_by_name
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@parquet_schema_evolution_by_name
+POSTHOOK: Input: default@parquet_schema_evolution_by_name@pname=1
+POSTHOOK: Input: default@parquet_schema_evolution_by_name@pname=2
+#### A masked pattern was here ####
+1.0	1	1
+2.0	2	2
+PREHOOK: query: -- Add a new field in the middle of the schema
+ALTER TABLE parquet_schema_evolution_by_name replace columns (col2 string, col1 double, col0 int)
+PREHOOK: type: ALTERTABLE_REPLACECOLS
+PREHOOK: Input: default@parquet_schema_evolution_by_name
+PREHOOK: Output: default@parquet_schema_evolution_by_name
+POSTHOOK: query: -- Add a new field in the middle of the schema
+ALTER TABLE parquet_schema_evolution_by_name replace columns (col2 string, col1 double, col0 int)
+POSTHOOK: type: ALTERTABLE_REPLACECOLS
+POSTHOOK: Input: default@parquet_schema_evolution_by_name
+POSTHOOK: Output: default@parquet_schema_evolution_by_name
+PREHOOK: query: INSERT INTO TABLE parquet_schema_evolution_by_name PARTITION (pname='3')
+  SELECT 'three', 3.0, 3
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@parquet_schema_evolution_by_name@pname=3
+POSTHOOK: query: INSERT INTO TABLE parquet_schema_evolution_by_name PARTITION (pname='3')
+  SELECT 'three', 3.0, 3
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@parquet_schema_evolution_by_name@pname=3
+POSTHOOK: Lineage: parquet_schema_evolution_by_name PARTITION(pname=3).col0 SIMPLE []
+POSTHOOK: Lineage: parquet_schema_evolution_by_name PARTITION(pname=3).col1 SIMPLE []
+POSTHOOK: Lineage: parquet_schema_evolution_by_name PARTITION(pname=3).col2 SIMPLE []
+PREHOOK: query: SELECT * FROM parquet_schema_evolution_by_name
+PREHOOK: type: QUERY
+PREHOOK: Input: default@parquet_schema_evolution_by_name
+PREHOOK: Input: default@parquet_schema_evolution_by_name@pname=1
+PREHOOK: Input: default@parquet_schema_evolution_by_name@pname=2
+PREHOOK: Input: default@parquet_schema_evolution_by_name@pname=3
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT * FROM parquet_schema_evolution_by_name
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@parquet_schema_evolution_by_name
+POSTHOOK: Input: default@parquet_schema_evolution_by_name@pname=1
+POSTHOOK: Input: default@parquet_schema_evolution_by_name@pname=2
+POSTHOOK: Input: default@parquet_schema_evolution_by_name@pname=3
+#### A masked pattern was here ####
+NULL	1.0	1	1
+NULL	2.0	2	2
+three	3.0	3	3
+PREHOOK: query: -- Table to test schema evolution at struct level
+CREATE TABLE parquet_schema_evolution_by_name_struct (f struct<col0:int,col1:double>)
+PARTITIONED BY (pname string)
+STORED AS PARQUET
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@parquet_schema_evolution_by_name_struct
+POSTHOOK: query: -- Table to test schema evolution at struct level
+CREATE TABLE parquet_schema_evolution_by_name_struct (f struct<col0:int,col1:double>)
+PARTITIONED BY (pname string)
+STORED AS PARQUET
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@parquet_schema_evolution_by_name_struct
+PREHOOK: query: -- Insert a first row with the original schema
+INSERT INTO TABLE parquet_schema_evolution_by_name_struct PARTITION (pname='1')
+  SELECT named_struct('col0', 1, 'col1', 1.0)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@parquet_schema_evolution_by_name_struct@pname=1
+POSTHOOK: query: -- Insert a first row with the original schema
+INSERT INTO TABLE parquet_schema_evolution_by_name_struct PARTITION (pname='1')
+  SELECT named_struct('col0', 1, 'col1', 1.0)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@parquet_schema_evolution_by_name_struct@pname=1
+POSTHOOK: Lineage: parquet_schema_evolution_by_name_struct PARTITION(pname=1).f EXPRESSION []
+PREHOOK: query: -- Reorder the columns within the schema
+ALTER TABLE parquet_schema_evolution_by_name_struct change column f f struct<col1:double,col0:int>
+PREHOOK: type: ALTERTABLE_RENAMECOL
+PREHOOK: Input: default@parquet_schema_evolution_by_name_struct
+PREHOOK: Output: default@parquet_schema_evolution_by_name_struct
+POSTHOOK: query: -- Reorder the columns within the schema
+ALTER TABLE parquet_schema_evolution_by_name_struct change column f f struct<col1:double,col0:int>
+POSTHOOK: type: ALTERTABLE_RENAMECOL
+POSTHOOK: Input: default@parquet_schema_evolution_by_name_struct
+POSTHOOK: Output: default@parquet_schema_evolution_by_name_struct
+PREHOOK: query: INSERT INTO TABLE parquet_schema_evolution_by_name_struct PARTITION (pname='2')
+  SELECT named_struct('col1', 2.0, 'col0', 2)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@parquet_schema_evolution_by_name_struct@pname=2
+POSTHOOK: query: INSERT INTO TABLE parquet_schema_evolution_by_name_struct PARTITION (pname='2')
+  SELECT named_struct('col1', 2.0, 'col0', 2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@parquet_schema_evolution_by_name_struct@pname=2
+POSTHOOK: Lineage: parquet_schema_evolution_by_name_struct PARTITION(pname=2).f EXPRESSION []
+PREHOOK: query: SELECT * FROM parquet_schema_evolution_by_name_struct
+PREHOOK: type: QUERY
+PREHOOK: Input: default@parquet_schema_evolution_by_name_struct
+PREHOOK: Input: default@parquet_schema_evolution_by_name_struct@pname=1
+PREHOOK: Input: default@parquet_schema_evolution_by_name_struct@pname=2
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT * FROM parquet_schema_evolution_by_name_struct
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@parquet_schema_evolution_by_name_struct
+POSTHOOK: Input: default@parquet_schema_evolution_by_name_struct@pname=1
+POSTHOOK: Input: default@parquet_schema_evolution_by_name_struct@pname=2
+#### A masked pattern was here ####
+{"col1":1.0,"col0":1}	1
+{"col1":2.0,"col0":2}	2
+PREHOOK: query: -- Add a new field in the middle of the schema
+ALTER TABLE parquet_schema_evolution_by_name_struct change column f f struct<col2:string,col1:double,col0:int>
+PREHOOK: type: ALTERTABLE_RENAMECOL
+PREHOOK: Input: default@parquet_schema_evolution_by_name_struct
+PREHOOK: Output: default@parquet_schema_evolution_by_name_struct
+POSTHOOK: query: -- Add a new field in the middle of the schema
+ALTER TABLE parquet_schema_evolution_by_name_struct change column f f struct<col2:string,col1:double,col0:int>
+POSTHOOK: type: ALTERTABLE_RENAMECOL
+POSTHOOK: Input: default@parquet_schema_evolution_by_name_struct
+POSTHOOK: Output: default@parquet_schema_evolution_by_name_struct
+PREHOOK: query: INSERT INTO TABLE parquet_schema_evolution_by_name_struct PARTITION (pname='3')
+  SELECT named_struct('col2', 'three', 'col1', 3.0, 'col0', 3)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@parquet_schema_evolution_by_name_struct@pname=3
+POSTHOOK: query: INSERT INTO TABLE parquet_schema_evolution_by_name_struct PARTITION (pname='3')
+  SELECT named_struct('col2', 'three', 'col1', 3.0, 'col0', 3)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@parquet_schema_evolution_by_name_struct@pname=3
+POSTHOOK: Lineage: parquet_schema_evolution_by_name_struct PARTITION(pname=3).f EXPRESSION []
+PREHOOK: query: SELECT * FROM parquet_schema_evolution_by_name_struct
+PREHOOK: type: QUERY
+PREHOOK: Input: default@parquet_schema_evolution_by_name_struct
+PREHOOK: Input: default@parquet_schema_evolution_by_name_struct@pname=1
+PREHOOK: Input: default@parquet_schema_evolution_by_name_struct@pname=2
+PREHOOK: Input: default@parquet_schema_evolution_by_name_struct@pname=3
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT * FROM parquet_schema_evolution_by_name_struct
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@parquet_schema_evolution_by_name_struct
+POSTHOOK: Input: default@parquet_schema_evolution_by_name_struct@pname=1
+POSTHOOK: Input: default@parquet_schema_evolution_by_name_struct@pname=2
+POSTHOOK: Input: default@parquet_schema_evolution_by_name_struct@pname=3
+#### A masked pattern was here ####
+{"col2":null,"col1":1.0,"col0":1}	1
+{"col2":null,"col1":2.0,"col0":2}	2
+{"col2":"three","col1":3.0,"col0":3}	3
+PREHOOK: query: -- Remove a field from the middle of the schema
+ALTER TABLE parquet_schema_evolution_by_name_struct change column f f struct<col2:string,col0:int>
+PREHOOK: type: ALTERTABLE_RENAMECOL
+PREHOOK: Input: default@parquet_schema_evolution_by_name_struct
+PREHOOK: Output: default@parquet_schema_evolution_by_name_struct
+POSTHOOK: query: -- Remove a field from the middle of the schema
+ALTER TABLE parquet_schema_evolution_by_name_struct change column f f struct<col2:string,col0:int>
+POSTHOOK: type: ALTERTABLE_RENAMECOL
+POSTHOOK: Input: default@parquet_schema_evolution_by_name_struct
+POSTHOOK: Output: default@parquet_schema_evolution_by_name_struct
+PREHOOK: query: INSERT INTO TABLE parquet_schema_evolution_by_name_struct PARTITION (pname='4')
+  SELECT named_struct('col2', 'four', 'col0', 4)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@parquet_schema_evolution_by_name_struct@pname=4
+POSTHOOK: query: INSERT INTO TABLE parquet_schema_evolution_by_name_struct PARTITION (pname='4')
+  SELECT named_struct('col2', 'four', 'col0', 4)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@parquet_schema_evolution_by_name_struct@pname=4
+POSTHOOK: Lineage: parquet_schema_evolution_by_name_struct PARTITION(pname=4).f EXPRESSION []
+PREHOOK: query: SELECT * FROM parquet_schema_evolution_by_name_struct
+PREHOOK: type: QUERY
+PREHOOK: Input: default@parquet_schema_evolution_by_name_struct
+PREHOOK: Input: default@parquet_schema_evolution_by_name_struct@pname=1
+PREHOOK: Input: default@parquet_schema_evolution_by_name_struct@pname=2
+PREHOOK: Input: default@parquet_schema_evolution_by_name_struct@pname=3
+PREHOOK: Input: default@parquet_schema_evolution_by_name_struct@pname=4
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT * FROM parquet_schema_evolution_by_name_struct
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@parquet_schema_evolution_by_name_struct
+POSTHOOK: Input: default@parquet_schema_evolution_by_name_struct@pname=1
+POSTHOOK: Input: default@parquet_schema_evolution_by_name_struct@pname=2
+POSTHOOK: Input: default@parquet_schema_evolution_by_name_struct@pname=3
+POSTHOOK: Input: default@parquet_schema_evolution_by_name_struct@pname=4
+#### A masked pattern was here ####
+{"col2":null,"col0":1}	1
+{"col2":null,"col0":2}	2
+{"col2":"three","col0":3}	3
+{"col2":"four","col0":4}	4
+PREHOOK: query: -- Clean up
+DROP TABLE parquet_schema_evolution_by_name
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@parquet_schema_evolution_by_name
+PREHOOK: Output: default@parquet_schema_evolution_by_name
+POSTHOOK: query: -- Clean up
+DROP TABLE parquet_schema_evolution_by_name
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@parquet_schema_evolution_by_name
+POSTHOOK: Output: default@parquet_schema_evolution_by_name
+PREHOOK: query: DROP TABLE parquet_schema_evolution_by_name_struct
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@parquet_schema_evolution_by_name_struct
+PREHOOK: Output: default@parquet_schema_evolution_by_name_struct
+POSTHOOK: query: DROP TABLE parquet_schema_evolution_by_name_struct
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@parquet_schema_evolution_by_name_struct
+POSTHOOK: Output: default@parquet_schema_evolution_by_name_struct

--- a/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorConverters.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorConverters.java
@@ -19,9 +19,12 @@
 package org.apache.hadoop.hive.serde2.objectinspector;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.JavaStringObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorConverter;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
@@ -42,7 +45,6 @@ import org.apache.hadoop.hive.serde2.objectinspector.primitive.SettableShortObje
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.SettableTimestampObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.VoidObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.WritableStringObjectInspector;
-import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
 
 /**
  * ObjectInspectorConverters.
@@ -153,6 +155,11 @@ public final class ObjectInspectorConverters {
    */
   public static Converter getConverter(ObjectInspector inputOI,
       ObjectInspector outputOI) {
+    return getConverter(inputOI, outputOI, null);
+  }
+
+  public static Converter getConverter(ObjectInspector inputOI,
+      ObjectInspector outputOI, Configuration conf) {
     // If the inputOI is the same as the outputOI, just return an
     // IdentityConverter.
     if (inputOI.equals(outputOI)) {
@@ -163,16 +170,16 @@ public final class ObjectInspectorConverters {
       return getConverter((PrimitiveObjectInspector) inputOI, (PrimitiveObjectInspector) outputOI);
     case STRUCT:
       return new StructConverter(inputOI,
-          (SettableStructObjectInspector) outputOI);
+          (SettableStructObjectInspector) outputOI, conf);
     case LIST:
       return new ListConverter(inputOI,
-          (SettableListObjectInspector) outputOI);
+          (SettableListObjectInspector) outputOI, conf);
     case MAP:
       return new MapConverter(inputOI,
-          (SettableMapObjectInspector) outputOI);
+          (SettableMapObjectInspector) outputOI, conf);
     case UNION:
       return new UnionConverter(inputOI,
-          (SettableUnionObjectInspector) outputOI);
+          (SettableUnionObjectInspector) outputOI, conf);
     default:
       throw new RuntimeException("Hive internal error: conversion of "
           + inputOI.getTypeName() + " to " + outputOI.getTypeName()
@@ -307,14 +314,16 @@ public final class ObjectInspectorConverters {
     ObjectInspector outputElementOI;
 
     ArrayList<Converter> elementConverters;
+    Configuration conf;
 
     Object output;
 
     public ListConverter(ObjectInspector inputOI,
-        SettableListObjectInspector outputOI) {
+        SettableListObjectInspector outputOI, Configuration conf) {
       if (inputOI instanceof ListObjectInspector) {
         this.inputOI = (ListObjectInspector)inputOI;
         this.outputOI = outputOI;
+        this.conf = conf;
         inputElementOI = this.inputOI.getListElementObjectInspector();
         outputElementOI = outputOI.getListElementObjectInspector();
         output = outputOI.create(0);
@@ -338,7 +347,7 @@ public final class ObjectInspectorConverters {
       // elements.
       int size = inputOI.getListLength(input);
       while (elementConverters.size() < size) {
-        elementConverters.add(getConverter(inputElementOI, outputElementOI));
+        elementConverters.add(getConverter(inputElementOI, outputElementOI, conf));
       }
 
       // Convert the elements
@@ -359,32 +368,75 @@ public final class ObjectInspectorConverters {
    */
   public static class StructConverter implements Converter {
 
+    private static class StructFieldConverter implements Converter {
+
+      int inputIndex;
+      Converter fieldTypeConverter;
+
+      public StructFieldConverter(int inputIndex, Converter fieldTypeConverter) {
+        this.inputIndex = inputIndex;
+        this.fieldTypeConverter = fieldTypeConverter;
+      }
+
+      @Override
+      public Object convert(Object input) {
+        return fieldTypeConverter.convert(input);
+      }
+    }
+
     StructObjectInspector inputOI;
     SettableStructObjectInspector outputOI;
 
     List<? extends StructField> inputFields;
     List<? extends StructField> outputFields;
 
+    // if input and output schemas differ, resolve struct cols by name or by index
+    boolean resolveByName = false;
+
     ArrayList<Converter> fieldConverters;
 
     Object output;
 
     public StructConverter(ObjectInspector inputOI,
-        SettableStructObjectInspector outputOI) {
+        SettableStructObjectInspector outputOI, Configuration conf) {
       if (inputOI instanceof StructObjectInspector) {
+        if (conf != null) {
+          resolveByName = conf.getBoolean(HiveConf.ConfVars.HIVE_STRUCT_SCHEMA_CONVERSION_BY_NAME.varname, false);
+        }
+
         this.inputOI = (StructObjectInspector)inputOI;
         this.outputOI = outputOI;
         inputFields = this.inputOI.getAllStructFieldRefs();
         outputFields = outputOI.getAllStructFieldRefs();
 
-        // If the output has some extra fields, set them to NULL.
-        int minFields = Math.min(inputFields.size(), outputFields.size());
-        fieldConverters = new ArrayList<Converter>(minFields);
-        for (int f = 0; f < minFields; f++) {
-          fieldConverters.add(getConverter(inputFields.get(f)
-              .getFieldObjectInspector(), outputFields.get(f)
-              .getFieldObjectInspector()));
+        if (resolveByName) {
+          Map<String, Integer> inputFieldIndicesByName = new HashMap<>();
+          for (int f = 0; f < inputFields.size(); f++) {
+            inputFieldIndicesByName.put(inputFields.get(f).getFieldName().toLowerCase(), f);
+          }
+
+          fieldConverters = new ArrayList<>(outputFields.size());
+          for (StructField out: outputFields) {
+            Integer indexInInput = inputFieldIndicesByName.get(out.getFieldName().toLowerCase());
+            if (indexInInput == null) {
+              fieldConverters.add(null);
+            } else {
+              fieldConverters.add(new StructFieldConverter(indexInInput,
+                      getConverter(inputFields.get(indexInInput).getFieldObjectInspector(),
+                              out.getFieldObjectInspector(), conf)));
+            }
+          }
+        } else {
+          // If the output has some extra fields, set them to NULL.
+          int minFields = Math.min(inputFields.size(), outputFields.size());
+          fieldConverters = new ArrayList<Converter>(minFields);
+          for (int f = 0; f < minFields; f++) {
+            fieldConverters.add(getConverter(
+                    inputFields.get(f).getFieldObjectInspector(),
+                    outputFields.get(f).getFieldObjectInspector(), conf));
+          }
         }
+
         output = outputOI.create();
       } else if (!(inputOI instanceof VoidObjectInspector)) {
         throw new RuntimeException("Hive internal error: conversion of " +
@@ -399,17 +451,33 @@ public final class ObjectInspectorConverters {
         return null;
       }
 
-      int minFields = Math.min(inputFields.size(), outputFields.size());
-      // Convert the fields
-      for (int f = 0; f < minFields; f++) {
-        Object inputFieldValue = inputOI.getStructFieldData(input, inputFields.get(f));
-        Object outputFieldValue = fieldConverters.get(f).convert(inputFieldValue);
-        outputOI.setStructFieldData(output, outputFields.get(f), outputFieldValue);
+      if (resolveByName) {
+        for (int f = 0; f < fieldConverters.size(); f++) {
+          StructFieldConverter converter = (StructFieldConverter) fieldConverters.get(f);
+          StructField out = outputFields.get(f);
+          if (converter == null) { // The field does not exist in the input
+            outputOI.setStructFieldData(output, out, null);
+          }
+          else {
+            Object inputFieldValue = inputOI.getStructFieldData(input, inputFields.get(converter.inputIndex));
+            Object outputFieldValue = converter.convert(inputFieldValue);
+            outputOI.setStructFieldData(output, out, outputFieldValue);
+          }
+        }
       }
+      else {
+        int minFields = Math.min(inputFields.size(), outputFields.size());
+        // Convert the fields
+        for (int f = 0; f < minFields; f++) {
+          Object inputFieldValue = inputOI.getStructFieldData(input, inputFields.get(f));
+          Object outputFieldValue = fieldConverters.get(f).convert(inputFieldValue);
+          outputOI.setStructFieldData(output, outputFields.get(f), outputFieldValue);
+        }
 
-      // set the extra fields to null
-      for (int f = minFields; f < outputFields.size(); f++) {
-        outputOI.setStructFieldData(output, outputFields.get(f), null);
+        // set the extra fields to null
+        for (int f = minFields; f < outputFields.size(); f++) {
+          outputOI.setStructFieldData(output, outputFields.get(f), null);
+        }
       }
 
       return output;
@@ -424,7 +492,7 @@ public final class ObjectInspectorConverters {
     UnionObjectInspector inputOI;
     SettableUnionObjectInspector outputOI;
 
-    // Object inspectors for the tags for the input and output unionss
+    // Object inspectors for the tags for the input and output unions
     List<? extends ObjectInspector> inputTagsOIs;
     List<? extends ObjectInspector> outputTagsOIs;
 
@@ -433,7 +501,7 @@ public final class ObjectInspectorConverters {
     Object output;
 
     public UnionConverter(ObjectInspector inputOI,
-        SettableUnionObjectInspector outputOI) {
+        SettableUnionObjectInspector outputOI, Configuration conf) {
       if (inputOI instanceof UnionObjectInspector) {
         this.inputOI = (UnionObjectInspector)inputOI;
         this.outputOI = outputOI;
@@ -444,7 +512,7 @@ public final class ObjectInspectorConverters {
         int minFields = Math.min(inputTagsOIs.size(), outputTagsOIs.size());
         fieldConverters = new ArrayList<Converter>(minFields);
         for (int f = 0; f < minFields; f++) {
-          fieldConverters.add(getConverter(inputTagsOIs.get(f), outputTagsOIs.get(f)));
+          fieldConverters.add(getConverter(inputTagsOIs.get(f), outputTagsOIs.get(f), conf));
         }
 
         // Create an empty output object which will be populated when convert() is invoked.
@@ -494,14 +562,16 @@ public final class ObjectInspectorConverters {
 
     ArrayList<Converter> keyConverters;
     ArrayList<Converter> valueConverters;
+    Configuration conf;
 
     Object output;
 
     public MapConverter(ObjectInspector inputOI,
-        SettableMapObjectInspector outputOI) {
+        SettableMapObjectInspector outputOI, Configuration conf) {
       if (inputOI instanceof MapObjectInspector) {
         this.inputOI = (MapObjectInspector)inputOI;
         this.outputOI = outputOI;
+        this.conf = conf;
         inputKeyOI = this.inputOI.getMapKeyObjectInspector();
         outputKeyOI = outputOI.getMapKeyObjectInspector();
         inputValueOI = this.inputOI.getMapValueObjectInspector();
@@ -535,8 +605,8 @@ public final class ObjectInspectorConverters {
       int size = map.size();
 
       while (keyConverters.size() < size) {
-        keyConverters.add(getConverter(inputKeyOI, outputKeyOI));
-        valueConverters.add(getConverter(inputValueOI, outputValueOI));
+        keyConverters.add(getConverter(inputKeyOI, outputKeyOI, conf));
+        valueConverters.add(getConverter(inputValueOI, outputValueOI, conf));
       }
 
       // CLear the output

--- a/serde/src/test/org/apache/hadoop/hive/serde2/objectinspector/TestObjectInspectorConverters.java
+++ b/serde/src/test/org/apache/hadoop/hive/serde2/objectinspector/TestObjectInspectorConverters.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hive.serde2.objectinspector;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import junit.framework.TestCase;
@@ -25,6 +26,7 @@ import junit.framework.TestCase;
 import org.apache.hadoop.hive.common.type.HiveChar;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
 import org.apache.hadoop.hive.common.type.HiveVarchar;
+import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.serde2.io.ByteWritable;
 import org.apache.hadoop.hive.serde2.io.DoubleWritable;
 import org.apache.hadoop.hive.serde2.io.HiveCharWritable;
@@ -355,6 +357,82 @@ public class TestObjectInspectorConverters extends TestCase {
       throw e;
     }
 
+  }
+
+  public void testStructSchemaEvolution() throws Throwable {
+
+    HiveConf conf = new HiveConf();
+    conf.setBoolVar(HiveConf.ConfVars.HIVE_STRUCT_SCHEMA_CONVERSION_BY_NAME, true);
+
+    //case 1 : input has more fields than output
+    List<String> inputFields = Arrays.asList("col1", "col2", "col3");
+    List<ObjectInspector> inputOIs = Arrays.asList(new ObjectInspector[]{
+            PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+            PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+            PrimitiveObjectInspectorFactory.javaBooleanObjectInspector});
+
+    List<String> outputFields = Arrays.asList("col2");
+    List<ObjectInspector> outputOIs = Arrays.asList(new ObjectInspector[]{
+            PrimitiveObjectInspectorFactory.javaStringObjectInspector});
+
+    Converter structConverter = ObjectInspectorConverters.getConverter(ObjectInspectorFactory.getStandardStructObjectInspector(inputFields, inputOIs),
+            ObjectInspectorFactory.getStandardStructObjectInspector(outputFields, outputOIs), conf);
+
+    ArrayList<Object> struct1In = new ArrayList<>();
+    struct1In.add(1);
+    struct1In.add("two");
+    struct1In.add(true);
+
+    ArrayList struct1Out = (ArrayList) structConverter.convert(struct1In);
+    assertEquals(1, struct1Out.size());
+    assertEquals("two", struct1Out.get(0));
+
+
+    //case 2 : input has less fields than output
+    List<String> inputFields2 = Arrays.asList("col1", "col2");
+    List<ObjectInspector> inputOIs2 = Arrays.asList(new ObjectInspector[]{
+            PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+            PrimitiveObjectInspectorFactory.javaStringObjectInspector});
+
+    List<String> outputFields2 = Arrays.asList("col0", "col1", "col2");
+    List<ObjectInspector> outputOIs2 = Arrays.asList(new ObjectInspector[]{
+            PrimitiveObjectInspectorFactory.javaBooleanObjectInspector,
+            PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+            PrimitiveObjectInspectorFactory.javaStringObjectInspector});
+
+    Converter structConverter2 = ObjectInspectorConverters.getConverter(ObjectInspectorFactory.getStandardStructObjectInspector(inputFields2, inputOIs2),
+            ObjectInspectorFactory.getStandardStructObjectInspector(outputFields2, outputOIs2), conf);
+    ArrayList<Object> struct2In = new ArrayList<Object>();
+    struct2In.add(1);
+    struct2In.add("two");
+
+    ArrayList struct2Out = (ArrayList) structConverter2.convert(struct2In);
+    assertEquals(3, struct2Out.size());
+    assertEquals(null, struct2Out.get(0));
+    assertEquals(1, struct2Out.get(1));
+    assertEquals("two", struct2Out.get(2));
+
+    //case 3 : input and output have the same fields with a different ordering
+    List<String> inputFields3 = Arrays.asList("col1", "col2");
+    List<ObjectInspector> inputOIs3 = Arrays.asList(new ObjectInspector[]{
+            PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+            PrimitiveObjectInspectorFactory.javaStringObjectInspector});
+
+    List<String> outputFields3 = Arrays.asList("col2", "col1");
+    List<ObjectInspector> outputOIs3 = Arrays.asList(new ObjectInspector[]{
+            PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+            PrimitiveObjectInspectorFactory.javaIntObjectInspector});
+
+    Converter structConverter3 = ObjectInspectorConverters.getConverter(ObjectInspectorFactory.getStandardStructObjectInspector(inputFields3, inputOIs3),
+            ObjectInspectorFactory.getStandardStructObjectInspector(outputFields3, outputOIs3), conf);
+    ArrayList<Object> struct3In = new ArrayList<>();
+    struct3In.add(1);
+    struct3In.add("two");
+
+    ArrayList struct3Out = (ArrayList) structConverter3.convert(struct3In);
+    assertEquals(2, struct3Out.size());
+    assertEquals("two", struct3Out.get(0));
+    assertEquals(1, struct3Out.get(1));
   }
 
   public void testGetConvertedOI() throws Throwable {


### PR DESCRIPTION
Backport of https://github.com/criteo-forks/hive/pull/37

This change allows the possibility of using names to match schemas between a partition and a table and patches parquet implementation to make it compatible with it. This behavior is disabled by default and needs the usage of two configuration variables. This has only be tested with parquet datasets.

The set of changes is the following:

Add a new behavior to the StructConverter to allow matching by name instead of by index. The activation of this behavior is done through a configuration variable, so the ObjectInspectorConverters API has been changed to allow the passing of the config.
Add a new behavior to the parquet reader to use the partition schema instead of the table schema to shape the output data. This change also need the setting of a new configuration variable, although this has only been done for safety in backwards compatibility. The activation of this change should be compatible with the old behavior for named-based access to parquet files but further testing needs to be done.