### PR TITLE
Use flag to decide if materialized views are loaded on startup

### DIFF
--- a/service/src/java/org/apache/hive/service/server/HiveServer2.java
+++ b/service/src/java/org/apache/hive/service/server/HiveServer2.java
@@ -162,13 +162,20 @@ public class HiveServer2 extends CompositeService {
       LlapRegistryService.getClient(hiveConf);
     }
 
-    // Create views registry
-    try {
-      Hive sessionHive = Hive.get(hiveConf);
-      HiveMaterializedViewsRegistry.get().init(sessionHive);
-    } catch (HiveException e) {
-      throw new RuntimeException("Failed to get metastore connection", e);
+    boolean loadMaterializedViewsOnStartup = hiveConf.getBoolVar(ConfVars.HIVE_MATERIALIZED_VIEW_ENABLE_AUTO_REWRITING);
+    if (loadMaterializedViewsOnStartup) {
+      // Create views registry
+      LOG.info("Loading materialized views from the metastore");
+      try {
+        Hive sessionHive = Hive.get(hiveConf);
+        HiveMaterializedViewsRegistry.get().init(sessionHive);
+      } catch (HiveException e) {
+        throw new RuntimeException("Failed to get metastore connection", e);
+      }
+    } else {
+      LOG.info("Skip loading materialized views from the metastore");
     }
+
     // Setup web UI
     try {
       int webUIPort =


### PR DESCRIPTION
In this change, I add the possibility to skip loading materialized views when HiveServer2 starts.

The rationale for this change:
On startup, HiveServer2 tries to cache materialized views in the HiveMaterializedViewsRegistry. To do so, it first get all databases, then for each database gets all the tables, and cache those that are identified as materialized view. It does so on the main thread, with retries, and that delays the availability of the Hive Server, causing healthcheck issues.