### PR TITLE
Support column statistics when partition values contain leading 0s

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/ColumnStatsSemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/ColumnStatsSemanticAnalyzer.java
@@ -264,7 +264,16 @@ public class ColumnStatsSemanticAnalyzer extends SemanticAnalyzer {
 
     if (isPartitionStats) {
       for (FieldSchema fs : tbl.getPartCols()) {
-        rewrittenQueryBuilder.append(" , `" + fs.getName() + "`");
+        String fieldName = fs.getName();
+        if (partSpec.containsKey(fieldName)) {
+          rewrittenQueryBuilder.append(" , '");
+          rewrittenQueryBuilder.append(partSpec.get(fieldName));
+          rewrittenQueryBuilder.append("' as `");
+          rewrittenQueryBuilder.append(fieldName);
+          rewrittenQueryBuilder.append("`");
+        } else {
+          rewrittenQueryBuilder.append(" , `" + fieldName + "`");
+        }
       }
     }
     rewrittenQueryBuilder.append(" from `");


### PR DESCRIPTION
When analyzing columns, Hive computes stats correctly but fails to
insert them in the Metastore when the partition contains values
with leading zeros (eg. day=2020-05-04/hour=01 where hour is
declared as integer).
This change uses constant literals as the partition values when
inserting statistics, allowing to have formatted numerals as
partition values.