### PR TITLE
Add dbName to MetaStoreEndFunctionContext

### DIFF
--- a/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
+++ b/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
@@ -817,7 +817,12 @@ public class HiveMetaStore extends ThriftHiveMetastore {
     }
     private void endFunction(String function, boolean successful, Exception e,
                             String inputTableName) {
-      endFunction(function, new MetaStoreEndFunctionContext(successful, e, inputTableName));
+      endFunction(function, successful, e, null, inputTableName);
+    }
+
+    private void endFunction(String function, boolean successful, Exception e,
+                             String inputDbName, String inputTableName) {
+      endFunction(function, new MetaStoreEndFunctionContext(successful, e, inputDbName, inputTableName));
     }
 
     private void endFunction(String function, MetaStoreEndFunctionContext context) {
@@ -1513,7 +1518,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
           throw newMetaException(e);
         }
       } finally {
-        endFunction("create_table", success, ex, tbl.getTableName());
+        endFunction("create_table", success, ex, tbl.getDbName(), tbl.getTableName());
       }
     }
 
@@ -1542,7 +1547,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
           throw newMetaException(e);
         }
       } finally {
-        endFunction("create_table", success, ex, tbl.getTableName());
+        endFunction("create_table", success, ex, tbl.getDbName(), tbl.getTableName());
       }
     }
 
@@ -1932,7 +1937,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
           throw newMetaException(e);
         }
       } finally {
-        endFunction("drop_table", success, ex, name);
+        endFunction("drop_table", success, ex, dbname, name);
       }
 
     }
@@ -1986,7 +1991,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
         ex = e;
         throw e;
       } finally {
-        endFunction("get_table", t != null, ex, name);
+        endFunction("get_table", t != null, ex, dbname, name);
       }
       return t;
     }
@@ -2124,7 +2129,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
           throw newMetaException(e);
         }
       } finally {
-        endFunction("get_multi_table", tables != null, ex, join(tableNames, ","));
+        endFunction("get_multi_table", tables != null, ex, join(tableNames, ",")); // TODO
       }
       return tables;
     }
@@ -2173,7 +2178,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
           throw newMetaException(e);
         }
       } finally {
-        endFunction("get_table_names_by_filter", tables != null, ex, join(tables, ","));
+        endFunction("get_table_names_by_filter", tables != null, ex, join(tables, ",")); // TODO
       }
       return tables;
     }
@@ -2318,7 +2323,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
           throw newMetaException(e);
         }
       } finally {
-        endFunction("append_partition", ret != null, ex, tableName);
+        endFunction("append_partition", ret != null, ex, dbName, tableName);
       }
       return ret;
     }
@@ -2593,8 +2598,9 @@ public class HiveMetaStore extends ThriftHiveMetastore {
           throw newMetaException(e);
         }
       } finally {
+        String dbName = parts.get(0).getDbName();
         String tableName = parts.get(0).getTableName();
-        endFunction("add_partition", ret != null, ex, tableName);
+        endFunction("add_partition", ret != null, ex, dbName, tableName);
       }
       return ret;
     }
@@ -2921,7 +2927,13 @@ public class HiveMetaStore extends ThriftHiveMetastore {
           throw newMetaException(e);
         }
       } finally {
-        endFunction("add_partition", ret != null, ex, part != null ?  part.getTableName(): null);
+        String dbName = null;
+        String tableName = null;
+        if (part != null) {
+          dbName = part.getDbName();
+          tableName = part.getTableName();
+        }
+        endFunction("add_partition", ret != null, ex, dbName, tableName);
       }
       return ret;
     }
@@ -3385,7 +3397,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
         ex = e;
         rethrowException(e);
       } finally {
-        endFunction("drop_partition", ret, ex, tbl_name);
+        endFunction("drop_partition", ret, ex, db_name, tbl_name);
       }
       return ret;
 
@@ -3411,7 +3423,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
           throw newMetaException(e);
         }
       } finally {
-        endFunction("get_partition", ret != null, ex, tbl_name);
+        endFunction("get_partition", ret != null, ex, db_name, tbl_name);
       }
       return ret;
     }
@@ -3458,7 +3470,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
         ex = e;
         rethrowException(e);
       } finally {
-        endFunction("get_partition_with_auth", ret != null, ex, tbl_name);
+        endFunction("get_partition_with_auth", ret != null, ex, db_name, tbl_name);
       }
       return ret;
     }
@@ -3483,7 +3495,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
           throw newMetaException(e);
         }
       } finally {
-        endFunction("get_partitions", ret != null, ex, tbl_name);
+        endFunction("get_partitions", ret != null, ex, db_name, tbl_name);
       }
       return ret;
 
@@ -3509,7 +3521,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
         ex = e;
         rethrowException(e);
       } finally {
-        endFunction("get_partitions_with_auth", ret != null, ex, tblName);
+        endFunction("get_partitions_with_auth", ret != null, ex, dbName, tblName);
       }
       return ret;
 
@@ -3573,7 +3585,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
         return partitionSpecs;
       }
       finally {
-        endFunction("get_partitions_pspec", partitionSpecs != null && !partitionSpecs.isEmpty(), null, tbl_name);
+        endFunction("get_partitions_pspec", partitionSpecs != null && !partitionSpecs.isEmpty(), null, dbName, tbl_name);
       }
     }
 
@@ -3716,7 +3728,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
           throw newMetaException(e);
         }
       } finally {
-        endFunction("get_partition_names", ret != null, ex, tbl_name);
+        endFunction("get_partition_names", ret != null, ex, db_name, tbl_name);
       }
       return ret;
     }
@@ -3809,7 +3821,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
           throw newMetaException(e);
         }
       } finally {
-        endFunction("alter_partition", oldPart != null, ex, tbl_name);
+        endFunction("alter_partition", oldPart != null, ex, db_name, tbl_name);
       }
     }
 
@@ -3882,7 +3894,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
           throw newMetaException(e);
         }
       } finally {
-        endFunction("alter_partition", oldParts != null, ex, tbl_name);
+        endFunction("alter_partition", oldParts != null, ex, db_name, tbl_name);
       }
     }
 
@@ -3929,7 +3941,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
           ms.rollbackTransaction();
         }
 
-        endFunction("alter_index", success, ex, base_table_name);
+        endFunction("alter_index", success, ex, dbname, base_table_name);
 
         if (!listeners.isEmpty()) {
           MetaStoreListenerNotifier.notifyEvent(listeners,
@@ -4024,7 +4036,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
           throw newMetaException(e);
         }
       } finally {
-        endFunction("alter_table", success, ex, name);
+        endFunction("alter_table", success, ex, dbname, name);
       }
     }
 
@@ -4157,7 +4169,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
         if (orgHiveLoader != null) {
           curConf.setClassLoader(orgHiveLoader);
         }
-        endFunction("get_fields_with_environment_context", ret != null, ex, tableName);
+        endFunction("get_fields_with_environment_context", ret != null, ex, db, tableName);
       }
 
       return ret;
@@ -4242,7 +4254,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
           throw me;
         }
       } finally {
-        endFunction("get_schema_with_environment_context", success, ex, tableName);
+        endFunction("get_schema_with_environment_context", success, ex, db, tableName);
       }
     }
 
@@ -4363,7 +4375,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
         ex = e;
         rethrowException(e);
       } finally {
-        endFunction("get_partition_by_name", ret != null, ex, tbl_name);
+        endFunction("get_partition_by_name", ret != null, ex, db_name, tbl_name);
       }
       return ret;
     }
@@ -4402,7 +4414,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
           throw newMetaException(e);
         }
       } finally {
-        endFunction("append_partition_by_name", ret != null, ex, tbl_name);
+        endFunction("append_partition_by_name", ret != null, ex, db_name, tbl_name);
       }
       return ret;
     }
@@ -4450,7 +4462,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
         ex = e;
         rethrowException(e);
       } finally {
-        endFunction("drop_partition_by_name", ret, ex, tbl_name);
+        endFunction("drop_partition_by_name", ret, ex, db_name, tbl_name);
       }
 
       return ret;
@@ -4471,7 +4483,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
         ex = e;
         rethrowException(e);
       } finally {
-        endFunction("get_partitions_ps", ret != null, ex, tbl_name);
+        endFunction("get_partitions_ps", ret != null, ex, db_name, tbl_name);
       }
 
       return ret;
@@ -4497,7 +4509,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
         ex = e;
         rethrowException(e);
       } finally {
-        endFunction("get_partitions_ps_with_auth", ret != null, ex, tbl_name);
+        endFunction("get_partitions_ps_with_auth", ret != null, ex, db_name, tbl_name);
       }
       return ret;
     }
@@ -4516,7 +4528,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
         ex = e;
         rethrowException(e);
       } finally {
-        endFunction("get_partitions_names_ps", ret != null, ex, tbl_name);
+        endFunction("get_partitions_names_ps", ret != null, ex, db_name, tbl_name);
       }
       return ret;
     }
@@ -4564,8 +4576,9 @@ public class HiveMetaStore extends ThriftHiveMetastore {
           throw newMetaException(e);
         }
       } finally {
+        String dbName = indexTable != null ? indexTable.getDbName() : null;
         String tableName = indexTable != null ? indexTable.getTableName() : null;
-        endFunction("add_index", ret != null, ex, tableName);
+        endFunction("add_index", ret != null, ex, dbName, tableName);
       }
       return ret;
     }
@@ -4663,7 +4676,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
         ex = e;
         rethrowException(e);
       } finally {
-        endFunction("drop_index_by_name", ret, ex, tblName);
+        endFunction("drop_index_by_name", ret, ex, dbName, tblName);
       }
 
       return ret;
@@ -4754,7 +4767,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
         ex = e;
         rethrowException(e);
       } finally {
-        endFunction("get_index_by_name", ret != null, ex, tblName);
+        endFunction("get_index_by_name", ret != null, ex, dbName, tblName);
       }
       return ret;
     }
@@ -4790,7 +4803,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
           throw newMetaException(e);
         }
       } finally {
-        endFunction("get_index_names", ret != null, ex, tblName);
+        endFunction("get_index_names", ret != null, ex, dbName, tblName);
       }
       return ret;
     }
@@ -4809,7 +4822,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
         ex = e;
         rethrowException(e);
       } finally {
-        endFunction("get_indexes", ret != null, ex, tblName);
+        endFunction("get_indexes", ret != null, ex, dbName, tblName);
       }
       return ret;
     }
@@ -4852,7 +4865,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
         }
         return statsObj;
       } finally {
-        endFunction("get_column_statistics_by_table", statsObj != null, null, tableName);
+        endFunction("get_column_statistics_by_table", statsObj != null, null, dbName, tableName);
       }
     }
 
@@ -4872,7 +4885,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
         result = new TableStatsResult((cs == null || cs.getStatsObj() == null)
             ? Lists.<ColumnStatisticsObj>newArrayList() : cs.getStatsObj());
       } finally {
-        endFunction("get_table_statistics_req", result == null, null, tblName);
+        endFunction("get_table_statistics_req", result == null, null, dbName, tblName);
       }
       return result;
     }
@@ -4899,7 +4912,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
         }
         statsObj = list.get(0);
       } finally {
-        endFunction("get_column_statistics_by_partition", statsObj != null, null, tableName);
+        endFunction("get_column_statistics_by_partition", statsObj != null, null, dbName, tableName);
       }
       return statsObj;
     }
@@ -4930,7 +4943,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
         }
         result = new PartitionsStatsResult(map);
       } finally {
-        endFunction("get_partitions_statistics_req", result == null, null, tblName);
+        endFunction("get_partitions_statistics_req", result == null, null, dbName, tblName);
       }
       return result;
     }
@@ -4971,7 +4984,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
         ret = getMS().updateTableColumnStatistics(colStats);
         return ret;
       } finally {
-        endFunction("write_column_statistics", ret != false, null, tableName);
+        endFunction("write_column_statistics", ret != false, null, dbName, tableName);
       }
     }
 
@@ -5018,7 +5031,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
         ret = getMS().updatePartitionColumnStatistics(colStats, partVals);
         return ret;
       } finally {
-        endFunction("write_partition_column_statistics", ret != false, null, tableName);
+        endFunction("write_partition_column_statistics", ret != false, null, dbName, tableName);
       }
     }
 
@@ -5050,7 +5063,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
         ret = getMS().deletePartitionColumnStatistics(dbName, tableName,
                                                       convertedPartName, partVals, colName);
       } finally {
-        endFunction("delete_column_statistics_by_partition", ret != false, null, tableName);
+        endFunction("delete_column_statistics_by_partition", ret != false, null, dbName, tableName);
       }
       return ret;
     }
@@ -5072,7 +5085,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
       try {
         ret = getMS().deleteTableColumnStatistics(dbName, tableName, colName);
       } finally {
-        endFunction("delete_column_statistics_by_table", ret != false, null, tableName);
+        endFunction("delete_column_statistics_by_table", ret != false, null, dbName, tableName);
       }
       return ret;
     }
@@ -5092,7 +5105,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
         ex = e;
         rethrowException(e);
       } finally {
-        endFunction("get_partitions_by_filter", ret != null, ex, tblName);
+        endFunction("get_partitions_by_filter", ret != null, ex, dbName, tblName);
       }
       return ret;
     }
@@ -5124,7 +5137,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
         return partitionSpecs;
       }
       finally {
-        endFunction("get_partitions_by_filter_pspec", partitionSpecs != null && !partitionSpecs.isEmpty(), null, tblName);
+        endFunction("get_partitions_by_filter_pspec", partitionSpecs != null && !partitionSpecs.isEmpty(), null, dbName, tblName);
       }
     }
 
@@ -5146,7 +5159,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
         ex = e;
         rethrowException(e);
       } finally {
-        endFunction("get_partitions_by_expr", ret != null, ex, tblName);
+        endFunction("get_partitions_by_expr", ret != null, ex, dbName, tblName);
       }
       return ret;
     }
@@ -5178,7 +5191,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
         ex = e;
         rethrowException(e);
       } finally {
-        endFunction("get_num_partitions_by_filter", ret != -1, ex, tblName);
+        endFunction("get_num_partitions_by_filter", ret != -1, ex, dbName, tblName);
       }
       return ret;
     }
@@ -5196,7 +5209,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
         ex = e;
         rethrowException(e);
       } finally {
-        endFunction("get_num_partitions_by_expr", ret != -1, ex, tblName);
+        endFunction("get_num_partitions_by_expr", ret != -1, ex, dbName, tblName);
       }
       return ret;
     }
@@ -5216,7 +5229,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
         ex = e;
         rethrowException(e);
       } finally {
-        endFunction("get_partitions_by_names", ret != null, ex, tblName);
+        endFunction("get_partitions_by_names", ret != null, ex, dbName, tblName);
       }
       return ret;
     }
@@ -6070,7 +6083,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
           ms.rollbackTransaction();
         }
 
-        endFunction("markPartitionForEvent", tbl != null, ex, tbl_name);
+        endFunction("markPartitionForEvent", tbl != null, ex, db_name, tbl_name);
       }
     }
 
@@ -6104,7 +6117,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
           throw newMetaException(original);
         }
       } finally {
-                endFunction("isPartitionMarkedForEvent", ret != null, ex, tbl_name);
+                endFunction("isPartitionMarkedForEvent", ret != null, ex, db_name, tbl_name);
       }
 
       return ret;
@@ -6509,7 +6522,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
             lowerCaseColNames));
         return aggrStats;
       } finally {
-          endFunction("get_aggr_stats_for", aggrStats == null, null, request.getTblName());
+          endFunction("get_aggr_stats_for", aggrStats == null, null, request.getDbName(), request.getTblName());
       }
 
     }
@@ -6847,7 +6860,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
          throw newMetaException(e);
        }
      } finally {
-       endFunction("get_primary_keys", ret != null, ex, tbl_name);
+       endFunction("get_primary_keys", ret != null, ex, db_name, tbl_name);
      }
      return new PrimaryKeysResponse(ret);
     }
@@ -6877,7 +6890,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
           throw newMetaException(e);
         }
       } finally {
-        endFunction("get_foreign_keys", ret != null, ex, foreign_tbl_name);
+        endFunction("get_foreign_keys", ret != null, ex, foreign_db_name, foreign_tbl_name);
       }
       return new ForeignKeysResponse(ret);
     }
@@ -7451,3 +7464,4 @@ public class HiveMetaStore extends ThriftHiveMetastore {
     return fmHandlers;
   }
 }
+

--- a/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
+++ b/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
@@ -2129,7 +2129,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
           throw newMetaException(e);
         }
       } finally {
-        endFunction("get_multi_table", tables != null, ex, join(tableNames, ",")); // TODO
+        endFunction("get_multi_table", tables != null, ex, dbName, join(tableNames, ","));
       }
       return tables;
     }
@@ -2178,7 +2178,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
           throw newMetaException(e);
         }
       } finally {
-        endFunction("get_table_names_by_filter", tables != null, ex, join(tables, ",")); // TODO
+        endFunction("get_table_names_by_filter", tables != null, ex, dbName, join(tables, ","));
       }
       return tables;
     }

--- a/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
+++ b/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
@@ -951,7 +951,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
           throw newMetaException(e);
         }
       } finally {
-        endFunction("create_database", success, ex);
+        endFunction("create_database", success, ex, db.getName(), null);
       }
     }
 
@@ -970,7 +970,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
         ex = e;
         throw e;
       } finally {
-        endFunction("get_database", db != null, ex);
+        endFunction("get_database", db != null, ex, name, null);
       }
       return db;
     }
@@ -1012,7 +1012,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
         ex = e;
         rethrowException(e);
       } finally {
-        endFunction("alter_database", success, ex);
+        endFunction("alter_database", success, ex, dbName, null);
       }
     }
 
@@ -1166,7 +1166,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
 
       startFunction("drop_database", ": " + dbName);
       if (DEFAULT_DATABASE_NAME.equalsIgnoreCase(dbName)) {
-        endFunction("drop_database", false, null);
+        endFunction("drop_database", false, null, dbName, null);
         throw new MetaException("Can not drop default database");
       }
 
@@ -1190,7 +1190,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
           throw newMetaException(e);
         }
       } finally {
-        endFunction("drop_database", success, ex);
+        endFunction("drop_database", success, ex, dbName, null);
       }
     }
 
@@ -4057,7 +4057,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
           throw newMetaException(e);
         }
       } finally {
-        endFunction("get_tables", ret != null, ex);
+        endFunction("get_tables", ret != null, ex, dbname, null);
       }
       return ret;
     }
@@ -4079,7 +4079,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
           throw newMetaException(e);
         }
       } finally {
-        endFunction("get_tables_by_type", ret != null, ex);
+        endFunction("get_tables_by_type", ret != null, ex, dbname, null);
       }
       return ret;
     }
@@ -4100,7 +4100,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
           throw newMetaException(e);
         }
       } finally {
-        endFunction("get_all_tables", ret != null, ex);
+        endFunction("get_all_tables", ret != null, ex, dbname, null);
       }
       return ret;
     }
@@ -6293,7 +6293,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
         ex = e;
         throw newMetaException(e);
       } finally {
-        endFunction("get_functions", funcNames != null, ex);
+        endFunction("get_functions", funcNames != null, ex, dbName, null);
       }
 
       return funcNames;
@@ -6341,7 +6341,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
         ex = e;
         throw newMetaException(e);
       } finally {
-        endFunction("get_function", func != null, ex);
+        endFunction("get_function", func != null, ex, dbName, null);
       }
 
       return func;

--- a/metastore/src/java/org/apache/hadoop/hive/metastore/MetaStoreEndFunctionContext.java
+++ b/metastore/src/java/org/apache/hadoop/hive/metastore/MetaStoreEndFunctionContext.java
@@ -29,16 +29,18 @@ public class MetaStoreEndFunctionContext {
    */
   private final boolean success;
   private final Exception e;
+  private final String inputDbName;
   private final String inputTableName;
 
-  public MetaStoreEndFunctionContext(boolean success, Exception e, String inputTableName) {
+  public MetaStoreEndFunctionContext(boolean success, Exception e, String inputDbName, String inputTableName) {
     this.success = success;
     this.e = e;
+    this.inputDbName = inputDbName;
     this.inputTableName = inputTableName;
   }
 
   public MetaStoreEndFunctionContext(boolean success) {
-    this(success, null, null);
+    this(success, null, null, null);
   }
 
   /**


### PR DESCRIPTION
We need dbName to uniquely identify tables.