### PR TITLE
Remove database name from alter_database function

### DIFF
--- a/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
+++ b/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
@@ -1006,7 +1006,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
     @Override
     public void alter_database(final String dbName, final Database db)
         throws NoSuchObjectException, TException, MetaException {
-      startFunction("alter_database" + dbName);
+      startFunction("alter_database", ":" + dbName);
       boolean success = false;
       Exception ex = null;
       try {

--- a/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
+++ b/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
@@ -1006,7 +1006,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
     @Override
     public void alter_database(final String dbName, final Database db)
         throws NoSuchObjectException, TException, MetaException {
-      startFunction("alter_database", ":" + dbName);
+      startFunction("alter_database", ": " + dbName);
       boolean success = false;
       Exception ex = null;
       try {


### PR DESCRIPTION
In prometheus, this creates as many metrics as there are calls
to alter_database, Prometheus has trouble dealing with that
many metrics.
![Screenshot from 2020-06-09 15-02-01](https://user-images.githubusercontent.com/2479257/84150493-39b68000-aa62-11ea-89e8-291fefed3f24.png)