### PR TITLE
Fix alter table with Parquet schema inference

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/serde/ParquetHiveSerDe.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/serde/ParquetHiveSerDe.java
@@ -426,4 +426,8 @@ public class ParquetHiveSerDe extends AbstractSerDe {
 
     return null;
   }
+
+  public boolean shouldStoreFieldsInMetastore(Map<String, String> tableParams) {
+    return true;
+  }
 }

--- a/ql/src/test/queries/clientpositive/parquet_array_of_multi_field_struct_gen_schema.q
+++ b/ql/src/test/queries/clientpositive/parquet_array_of_multi_field_struct_gen_schema.q
@@ -13,4 +13,8 @@ LOCATION
 
 SELECT * FROM parquet_array_of_multi_field_structs_gen_schema;
 
+alter table parquet_array_of_multi_field_structs_gen_schema add columns (test string);
+
+SELECT * FROM parquet_array_of_multi_field_structs_gen_schema;
+
 DROP TABLE parquet_array_of_multi_field_structs_gen_schema;

--- a/ql/src/test/results/clientpositive/parquet_array_of_multi_field_struct_gen_schema.q.out
+++ b/ql/src/test/results/clientpositive/parquet_array_of_multi_field_struct_gen_schema.q.out
@@ -33,6 +33,23 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@parquet_array_of_multi_field_structs_gen_schema
 #### A masked pattern was here ####
 [{"latitude":0.0,"longitude":0.0},{"latitude":0.0,"longitude":180.0}]
+PREHOOK: query: alter table parquet_array_of_multi_field_structs_gen_schema add columns (test string)
+PREHOOK: type: ALTERTABLE_ADDCOLS
+PREHOOK: Input: default@parquet_array_of_multi_field_structs_gen_schema
+PREHOOK: Output: default@parquet_array_of_multi_field_structs_gen_schema
+POSTHOOK: query: alter table parquet_array_of_multi_field_structs_gen_schema add columns (test string)
+POSTHOOK: type: ALTERTABLE_ADDCOLS
+POSTHOOK: Input: default@parquet_array_of_multi_field_structs_gen_schema
+POSTHOOK: Output: default@parquet_array_of_multi_field_structs_gen_schema
+PREHOOK: query: SELECT * FROM parquet_array_of_multi_field_structs_gen_schema
+PREHOOK: type: QUERY
+PREHOOK: Input: default@parquet_array_of_multi_field_structs_gen_schema
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT * FROM parquet_array_of_multi_field_structs_gen_schema
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@parquet_array_of_multi_field_structs_gen_schema
+#### A masked pattern was here ####
+[{"latitude":0.0,"longitude":0.0},{"latitude":0.0,"longitude":180.0}]	NULL
 PREHOOK: query: DROP TABLE parquet_array_of_multi_field_structs_gen_schema
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@parquet_array_of_multi_field_structs_gen_schema


### PR DESCRIPTION
-- Alter table needs to load the columns, in order to add the new column
-- Due to schema inference patch, ParquetSerde is off the list "hive.serdes.using.metastore.for.schema" (which is needed to support creating a table without specifying columns).
-- This makes this code path load columns in a weird way (type is always 'from deserializer') that is not from the metastore, making add column fail.
-- But there seems to be a new Serde flag that can override it for this code path to force it to load from the metastore, even if it is off the list.