### PR TITLE
Fix Parquet schema evolution

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/MapredParquetInputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/MapredParquetInputFormat.java
@@ -16,6 +16,7 @@ package org.apache.hadoop.hive.ql.io.parquet;
 import java.io.IOException;
 
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedInputFormatInterface;
+import org.apache.hadoop.hive.ql.io.SelfDescribingInputFormatInterface;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.hive.ql.exec.Utilities;
@@ -37,7 +38,7 @@ import org.apache.parquet.hadoop.ParquetInputFormat;
  *       are not currently supported.  Removing the interface turns off vectorization.
  */
 public class MapredParquetInputFormat extends FileInputFormat<NullWritable, ArrayWritable>
-  implements VectorizedInputFormatInterface {
+  implements VectorizedInputFormatInterface, SelfDescribingInputFormatInterface {
 
   private static final Logger LOG = LoggerFactory.getLogger(MapredParquetInputFormat.class);
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/serde/ParquetHiveSerDe.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/serde/ParquetHiveSerDe.java
@@ -22,8 +22,6 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.hadoop.hive.ql.io.IOConstants;
 import org.apache.hadoop.hive.ql.io.parquet.convert.ParquetSchemaReader;
 import org.apache.hadoop.hive.ql.io.parquet.convert.ParquetToHiveSchemaConverter;
 //
@@ -118,22 +116,9 @@ public class ParquetHiveSerDe extends AbstractSerDe {
     final String columnTypeProperty = tbl.getProperty(serdeConstants.LIST_COLUMN_TYPES);
     final String columnNameDelimiter = tbl.containsKey(serdeConstants.COLUMN_NAME_DELIMITER) ? tbl
         .getProperty(serdeConstants.COLUMN_NAME_DELIMITER) : String.valueOf(SerDeUtils.COMMA);
-    final String schemaEvolutionColumnNames;
-    final String schemaEvolutionColumnTypes;
 
-    if (conf != null && HiveConf.getBoolVar(conf, HiveConf.ConfVars.HIVE_SCHEMA_EVOLUTION)) {
-      schemaEvolutionColumnNames = conf.get(IOConstants.SCHEMA_EVOLUTION_COLUMNS, "");
-      schemaEvolutionColumnTypes = conf.get(IOConstants.SCHEMA_EVOLUTION_COLUMNS_TYPES, "");
-    } else {
-      schemaEvolutionColumnNames = "";
-      schemaEvolutionColumnTypes = "";
-    }
 
-    if (!schemaEvolutionColumnNames.isEmpty() && !schemaEvolutionColumnTypes.isEmpty()) {
-      columnNames = Arrays.asList(schemaEvolutionColumnNames.split(","));
-      columnTypes = TypeInfoUtils.getTypeInfosFromTypeString(schemaEvolutionColumnTypes);
-    } else if (columnNameProperty.length() == 0 && columnTypeProperty.length() == 0) {
-
+    if (columnNameProperty.length() == 0 && columnTypeProperty.length() == 0) {
         final String locationProperty = tbl.getProperty("location", null);
         Path parquetFile = locationProperty != null ? getParquetFile(conf,
             new Path(locationProperty)) : null;

--- a/ql/src/test/queries/clientpositive/parquet_schema_evolution_partitions.q
+++ b/ql/src/test/queries/clientpositive/parquet_schema_evolution_partitions.q
@@ -31,7 +31,7 @@ SELECT * FROM parquet_schema_evolution_partitions;
 
 -- Change some types to a compatible supertype
 ALTER TABLE parquet_schema_evolution_partitions replace columns (col2 string, col1 array<bigint>, col0 bigint);
-INSERT INTO TABLE parquet_schema_evolution_partitions PARTITION (pname='3')
+INSERT INTO TABLE parquet_schema_evolution_partitions PARTITION (pname='4')
   SELECT 'four', array(cast(7 as bigint), 8, 9), 4;
 
 
@@ -74,6 +74,12 @@ INSERT INTO TABLE parquet_schema_evolution_partitions_struct PARTITION (pname='4
   SELECT named_struct('col2', 'four', 'col0', 4);
 
 SELECT * FROM parquet_schema_evolution_partitions_struct;
+
+-- Select from both table in a single MR job to make sure mappers reading a table do not use the schema of the other
+SELECT t1.*, t2.f
+FROM parquet_schema_evolution_partitions t1
+JOIN parquet_schema_evolution_partitions_struct t2
+  ON t1.pname = t2.pname;
 
 -- Clean up
 DROP TABLE parquet_schema_evolution_partitions;

--- a/ql/src/test/results/clientpositive/parquet_schema_evolution_partitions.q.out
+++ b/ql/src/test/results/clientpositive/parquet_schema_evolution_partitions.q.out
@@ -125,19 +125,19 @@ POSTHOOK: query: ALTER TABLE parquet_schema_evolution_partitions replace columns
 POSTHOOK: type: ALTERTABLE_REPLACECOLS
 POSTHOOK: Input: default@parquet_schema_evolution_partitions
 POSTHOOK: Output: default@parquet_schema_evolution_partitions
-PREHOOK: query: INSERT INTO TABLE parquet_schema_evolution_partitions PARTITION (pname='3')
+PREHOOK: query: INSERT INTO TABLE parquet_schema_evolution_partitions PARTITION (pname='4')
   SELECT 'four', array(cast(7 as bigint), 8, 9), 4
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
-PREHOOK: Output: default@parquet_schema_evolution_partitions@pname=3
-POSTHOOK: query: INSERT INTO TABLE parquet_schema_evolution_partitions PARTITION (pname='3')
+PREHOOK: Output: default@parquet_schema_evolution_partitions@pname=4
+POSTHOOK: query: INSERT INTO TABLE parquet_schema_evolution_partitions PARTITION (pname='4')
   SELECT 'four', array(cast(7 as bigint), 8, 9), 4
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
-POSTHOOK: Output: default@parquet_schema_evolution_partitions@pname=3
-POSTHOOK: Lineage: parquet_schema_evolution_partitions PARTITION(pname=3).col0 EXPRESSION []
-POSTHOOK: Lineage: parquet_schema_evolution_partitions PARTITION(pname=3).col1 EXPRESSION []
-POSTHOOK: Lineage: parquet_schema_evolution_partitions PARTITION(pname=3).col2 SIMPLE []
+POSTHOOK: Output: default@parquet_schema_evolution_partitions@pname=4
+POSTHOOK: Lineage: parquet_schema_evolution_partitions PARTITION(pname=4).col0 EXPRESSION []
+POSTHOOK: Lineage: parquet_schema_evolution_partitions PARTITION(pname=4).col1 EXPRESSION []
+POSTHOOK: Lineage: parquet_schema_evolution_partitions PARTITION(pname=4).col2 SIMPLE []
 PREHOOK: query: CREATE TABLE parquet_schema_evolution_partitions_output (col0 string, col1 bigint, col2 bigint)
 STORED AS PARQUET
 PREHOOK: type: CREATETABLE
@@ -156,6 +156,7 @@ PREHOOK: Input: default@parquet_schema_evolution_partitions
 PREHOOK: Input: default@parquet_schema_evolution_partitions@pname=1
 PREHOOK: Input: default@parquet_schema_evolution_partitions@pname=2
 PREHOOK: Input: default@parquet_schema_evolution_partitions@pname=3
+PREHOOK: Input: default@parquet_schema_evolution_partitions@pname=4
 PREHOOK: Output: default@parquet_schema_evolution_partitions_output
 POSTHOOK: query: INSERT INTO parquet_schema_evolution_partitions_output
 SELECT col2 AS col0, col1[0] AS col1, col0 as col2
@@ -165,6 +166,7 @@ POSTHOOK: Input: default@parquet_schema_evolution_partitions
 POSTHOOK: Input: default@parquet_schema_evolution_partitions@pname=1
 POSTHOOK: Input: default@parquet_schema_evolution_partitions@pname=2
 POSTHOOK: Input: default@parquet_schema_evolution_partitions@pname=3
+POSTHOOK: Input: default@parquet_schema_evolution_partitions@pname=4
 POSTHOOK: Output: default@parquet_schema_evolution_partitions_output
 POSTHOOK: Lineage: parquet_schema_evolution_partitions_output.col0 SIMPLE [(parquet_schema_evolution_partitions)parquet_schema_evolution_partitions.FieldSchema(name:col2, type:string, comment:), ]
 POSTHOOK: Lineage: parquet_schema_evolution_partitions_output.col1 EXPRESSION [(parquet_schema_evolution_partitions)parquet_schema_evolution_partitions.FieldSchema(name:col1, type:array<bigint>, comment:), ]
@@ -312,6 +314,42 @@ POSTHOOK: Input: default@parquet_schema_evolution_partitions_struct@pname=4
 {"col2":null,"col0":2}	2
 {"col2":"three","col0":3}	3
 {"col2":"four","col0":4}	4
+PREHOOK: query: SELECT t1.*, t2.f
+FROM parquet_schema_evolution_partitions t1
+JOIN parquet_schema_evolution_partitions_struct t2
+  ON t1.pname = t2.pname
+PREHOOK: type: QUERY
+PREHOOK: Input: default@parquet_schema_evolution_partitions
+PREHOOK: Input: default@parquet_schema_evolution_partitions@pname=1
+PREHOOK: Input: default@parquet_schema_evolution_partitions@pname=2
+PREHOOK: Input: default@parquet_schema_evolution_partitions@pname=3
+PREHOOK: Input: default@parquet_schema_evolution_partitions@pname=4
+PREHOOK: Input: default@parquet_schema_evolution_partitions_struct
+PREHOOK: Input: default@parquet_schema_evolution_partitions_struct@pname=1
+PREHOOK: Input: default@parquet_schema_evolution_partitions_struct@pname=2
+PREHOOK: Input: default@parquet_schema_evolution_partitions_struct@pname=3
+PREHOOK: Input: default@parquet_schema_evolution_partitions_struct@pname=4
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT t1.*, t2.f
+FROM parquet_schema_evolution_partitions t1
+JOIN parquet_schema_evolution_partitions_struct t2
+  ON t1.pname = t2.pname
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@parquet_schema_evolution_partitions
+POSTHOOK: Input: default@parquet_schema_evolution_partitions@pname=1
+POSTHOOK: Input: default@parquet_schema_evolution_partitions@pname=2
+POSTHOOK: Input: default@parquet_schema_evolution_partitions@pname=3
+POSTHOOK: Input: default@parquet_schema_evolution_partitions@pname=4
+POSTHOOK: Input: default@parquet_schema_evolution_partitions_struct
+POSTHOOK: Input: default@parquet_schema_evolution_partitions_struct@pname=1
+POSTHOOK: Input: default@parquet_schema_evolution_partitions_struct@pname=2
+POSTHOOK: Input: default@parquet_schema_evolution_partitions_struct@pname=3
+POSTHOOK: Input: default@parquet_schema_evolution_partitions_struct@pname=4
+#### A masked pattern was here ####
+NULL	[0,1]	1	1	{"col2":null,"col0":1}
+NULL	[2,3]	2	2	{"col2":null,"col0":2}
+three	[4,5,6]	3	3	{"col2":"three","col0":3}
+four	[7,8,9]	4	4	{"col2":"four","col0":4}
 PREHOOK: query: DROP TABLE parquet_schema_evolution_partitions
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@parquet_schema_evolution_partitions


### PR DESCRIPTION
- Revert all changes done on the ParquetSerDe
- Make `MapredParquetInputFormat` implement `SelfDescribingInputFormatInterface` like the Orc input format, such that the SerDe will be called with the proper schema evolution columns when necessary