### PR TITLE
[CVE-2021-44228] Update log4j2 version to 2.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
     <kryo.version>3.0.3</kryo.version>
     <libfb303.version>0.9.3</libfb303.version>
     <libthrift.version>0.9.3</libthrift.version>
-    <log4j2.version>2.6.2</log4j2.version>
+    <log4j2.version>2.15.0</log4j2.version>
     <opencsv.version>2.3</opencsv.version>
     <orc.version>1.3.4</orc.version>
     <mockito-all.version>1.9.5</mockito-all.version>


### PR DESCRIPTION
Solve https://www.lunasec.io/docs/blog/log4j-zero-day/