### PR TITLE
Force disruptor version in llap-server

### DIFF
--- a/llap-server/pom.xml
+++ b/llap-server/pom.xml
@@ -230,6 +230,11 @@
       <groupId>org.codehaus.jettison</groupId>
       <artifactId>jettison</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.lmax</groupId>
+      <artifactId>disruptor</artifactId>
+      <version>${disruptor.version}</version>
+    </dependency>
 
     <!-- test inter-project -->
     <dependency>


### PR DESCRIPTION
This will bring the right version when building the tar in packaging