### PR TITLE
Update log4j2 version to 2.17.1 to fix GHSA-8489-44mv-ggj8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
     <kryo.version>3.0.3</kryo.version>
     <libfb303.version>0.9.3</libfb303.version>
     <libthrift.version>0.9.3</libthrift.version>
-    <log4j2.version>2.17.0</log4j2.version>
+    <log4j2.version>2.17.1</log4j2.version>
     <opencsv.version>2.3</opencsv.version>
     <orc.version>1.3.4</orc.version>
     <mockito-all.version>1.9.5</mockito-all.version>


### PR DESCRIPTION
https://github.com/advisories/GHSA-8489-44mv-ggj8