### PR TITLE
Fix Code 1 error when partition path doesn't exist

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/Utilities.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/Utilities.java
@@ -3190,14 +3190,6 @@ public final class Utilities {
       LOG.info("Changed input file " + strPath + " to empty file " + newPath + " (" + oneRow + ")");
     }
 
-    // update the work
-
-    work.addPathToAlias(newPath, work.getPathToAliases().get(path));
-    work.removePathToAlias(path);
-
-    work.removePathToPartitionInfo(path);
-    work.addPathToPartitionInfo(newPath, partDesc);
-
     return newPath;
   }
 


### PR DESCRIPTION
This was due to the MapWork being updated twice.
The updatePathForMapWork method was actually not a new method but the isolation of instructions that already existed before in this function createDummyFileForEmptyPartition. So this is the result of an error when applying the patch HIVE-16949.