### PR TITLE
Set HMSHandler.getIPAddress to public

### DIFF
--- a/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
+++ b/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
@@ -193,7 +193,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
   public static final String ADMIN = "admin";
   public static final String PUBLIC = "public";
 
-  static HadoopThriftAuthBridge.Server saslServer;
+  private static HadoopThriftAuthBridge.Server saslServer;
   private static HiveDelegationTokenManager delegationTokenManager;
   private static boolean useSasl;
 

--- a/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
+++ b/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
@@ -193,7 +193,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
   public static final String ADMIN = "admin";
   public static final String PUBLIC = "public";
 
-  private static HadoopThriftAuthBridge.Server saslServer;
+  static HadoopThriftAuthBridge.Server saslServer;
   private static HiveDelegationTokenManager delegationTokenManager;
   private static boolean useSasl;
 
@@ -312,7 +312,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
           address, cmd).toString());
     }
 
-    private static String getIPAddress() {
+    public static String getIPAddress() {
       if (useSasl) {
         if (saslServer != null && saslServer.getRemoteAddress() != null) {
           return saslServer.getRemoteAddress().getHostAddress();


### PR DESCRIPTION
This is needed to access the remote address. Note that this method has been made public upstream as well.