### PR TITLE
Support MariaDB driver for Hive Metastore

### DIFF
--- a/metastore/src/java/org/apache/hadoop/hive/metastore/DatabaseProduct.java
+++ b/metastore/src/java/org/apache/hadoop/hive/metastore/DatabaseProduct.java
@@ -43,7 +43,7 @@ public enum DatabaseProduct {
       return MYSQL;
     } else if (productName.contains("mariadb")) {
       return MYSQL;
-    }else if (productName.contains("oracle")) {
+    } else if (productName.contains("oracle")) {
       return ORACLE;
     } else if (productName.contains("postgresql")) {
       return POSTGRES;

--- a/metastore/src/java/org/apache/hadoop/hive/metastore/DatabaseProduct.java
+++ b/metastore/src/java/org/apache/hadoop/hive/metastore/DatabaseProduct.java
@@ -41,7 +41,9 @@ public enum DatabaseProduct {
       return SQLSERVER;
     } else if (productName.contains("mysql")) {
       return MYSQL;
-    } else if (productName.contains("oracle")) {
+    } else if (productName.contains("mariadb")) {
+      return MYSQL;
+    }else if (productName.contains("oracle")) {
       return ORACLE;
     } else if (productName.contains("postgresql")) {
       return POSTGRES;


### PR DESCRIPTION
When using the MariaDB driver, HMS doesn't recognize MariaDB as a valid database product: [determineDatabaseProduct](https://github.com/criteo-forks/hive/blob/709af9e9bde8358e59a622e35747543775fc8565/metastore/src/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java#L122) 
When hive is testing compatibility with the direct sql mode, it needs to run the following query: `SELECT "DB_ID" from "DBS"`. This has quoted identifiers, which is not the default behavior in MySQL/MariaDB. During the [prepareTxn](https://github.com/criteo-forks/hive/blob/709af9e9bde8358e59a622e35747543775fc8565/metastore/src/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java#L1780) function, it sets the `ANSI_QUOTES` [SQL mode](https://mariadb.com/kb/en/sql-mode/#ansi_quotes) only for MySQL products
By recognizing MariaDB as a "MySQL" database product, we run that statement, and the DirectSQL queries will start working again.