### PR TITLE
CD_ID reuse for alter partitions

### DIFF
--- a/metastore/src/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/metastore/src/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -3571,7 +3571,7 @@ public class ObjectStore implements RawStore, Configurable {
     name = HiveStringUtils.normalizeIdentifier(name);
     dbname = HiveStringUtils.normalizeIdentifier(dbname);
     MPartition oldp = getMPartition(dbname, name, part_vals);
-    MPartition newp = convertToMPart(newPart, false);
+    MPartition newp = convertToMPart(newPart, true);
     if (oldp == null || newp == null) {
       throw new InvalidObjectException("partition does not exist.");
     }


### PR DESCRIPTION
Alter partitions behaves like add partitions when it comes to CD_ID reuse.

Prior to this change, alter partitions with schema changes would force the creation of a new CD_ID. However, with add partitions, if the schema of the partition is equal to that of the table, the table CD_ID is reused. This difference in behavior was introduced from the beginning without any specific justification (https://issues.apache.org/jira/browse/HIVE-2246).

Recently, this difference has been removed without an explicit mention, as the change was aiming at other optimizations (https://issues.apache.org/jira/browse/HIVE-28972). However, this PR applies one of the side effects of that change, so we stay aligned with future evolutions of HMS.

The choice of changing the boolean instead of the function signature is to reduce the surface of this commit and facilitate other changes / patches.